### PR TITLE
import xrange to support Python3

### DIFF
--- a/scripts/tf_cnn_benchmarks/inception_model.py
+++ b/scripts/tf_cnn_benchmarks/inception_model.py
@@ -36,6 +36,7 @@ References:
 
   Inception v4 and Resnet V2 architectures: http://arxiv.org/abs/1602.07261
 """
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 import model
 

--- a/scripts/tf_cnn_benchmarks/preprocessing.py
+++ b/scripts/tf_cnn_benchmarks/preprocessing.py
@@ -15,6 +15,7 @@
 
 """Image pre-processing utilities.
 """
+from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorflow.python.ops import data_flow_ops

--- a/scripts/tf_cnn_benchmarks/resnet_model.py
+++ b/scripts/tf_cnn_benchmarks/resnet_model.py
@@ -31,6 +31,8 @@ References:
   arXiv:1606.00915 (2016)
 """
 
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
 import model as model_lib
 
 

--- a/scripts/tf_cnn_benchmarks/vgg_model.py
+++ b/scripts/tf_cnn_benchmarks/vgg_model.py
@@ -23,6 +23,7 @@ References:
      Very Deep Convolutional Networks for Large-Scale Image Recognition
      arXiv:1409.1556 (2014)
 """
+from six.moves import xrange  # pylint: disable=redefined-builtin
 
 import model
 


### PR DESCRIPTION
Files which mention xrange should import xrange.
After the patch:
```
$ ag xrange
resnet_model.py
34:from six.moves import xrange  # pylint: disable=redefined-builtin
59:    for _ in xrange(self.layer_counts[0]):
61:    for i in xrange(self.layer_counts[1]):
64:    for i in xrange(self.layer_counts[2]):
67:    for i in xrange(self.layer_counts[3]):

inception_model.py
39:from six.moves import xrange  # pylint: disable=redefined-builtin
183:    for _ in xrange(4):
186:    for _ in xrange(7):
189:    for _ in xrange(3):

tf_cnn_benchmarks.py
32:from six.moves import xrange  # pylint: disable=redefined-builtin
804:                        for i in xrange(FLAGS.num_gpus)]
889:      for i in xrange(len(enqueue_ops)):
899:      for step in xrange(self.num_batches):
971:      for i in xrange(len(enqueue_ops)):

vgg_model.py
26:from six.moves import xrange  # pylint: disable=redefined-builtin
34:  for _ in xrange(num_conv_layers[0]):
37:  for _ in xrange(num_conv_layers[1]):
40:  for _ in xrange(num_conv_layers[2]):
43:  for _ in xrange(num_conv_layers[3]):
46:  for _ in xrange(num_conv_layers[4]):

preprocessing.py
18:from six.moves import xrange  # pylint: disable=redefined-builtin
370:      for i in xrange(self.batch_size):
378:      for device_index in xrange(self.device_count):
```