### PR TITLE
Fix: TypeError: 'zip' object is not subscriptable, In python3.5 …

### DIFF
--- a/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py
+++ b/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py
@@ -1268,7 +1268,7 @@ class BenchmarkCNN(object):
 
       param_refs = self.variable_mgr.trainable_variables_on_device(
           device_num, writable=True)
-      gradvars = zip(grads, param_refs)
+      gradvars = list(zip(grads, param_refs))
       return (loss, gradvars)
 
   def add_sync_queues_and_barrier(self, name_prefix,


### PR DESCRIPTION
…on3.5

In Python 2, zip returned a list. In Python 3, zip returns an iterable object. But you can make it into a list just by calling list, e.g. list(zip(*ngram))
Refer : http://stackoverflow.com/questions/27431390/typeerror-zip-object-is-not-subscriptable/27431433