### PR TITLE
Display 90 instead of 30 days of benchmark history on benchmark dashb…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,7 @@
    * Optionally, you can pass flags to your benchmark by adding `args` list.
 5. Send PR with the changes to annarev.
 
+Currently running benchmarks:
+https://benchmarks-dot-tensorflow-testing.appspot.com/
+
 For any questions, please contact annarev@google.com.

--- a/dashboard_app/main.py
+++ b/dashboard_app/main.py
@@ -29,7 +29,7 @@ from google.cloud import datastore
 app = Flask(__name__)
 
 # How much data to fetch for graphing.
-_DAYS_TO_FETCH = 30
+_DAYS_TO_FETCH = 90
 # Don't show a benchmark in benchmark list if it hasn't been run
 # for this many days.
 _MAX_DAYS_WITHOUT_RUN = 14


### PR DESCRIPTION
…oard. Also, added a link to benchmark dashboard to the README file.