### PR TITLE
fix the bug of _eval() function  while variable_update = parameter_server|distributed_replicated

### DIFF
--- a/scripts/tf_cnn_benchmarks/variable_mgr.py
+++ b/scripts/tf_cnn_benchmarks/variable_mgr.py
@@ -202,7 +202,11 @@ class VariableMgr(object):
     else:
       params = tf.trainable_variables()
     return params
-
+  def get_variables_to_save(self):
+    """ it decides what variables collection will be used to save to checkpoint 
+         tf.global_variables() as default 
+    """  
+    return tf.global_variables()
 
 class VariableMgrIndependent(VariableMgr):
   """VariableMgr that implements the --independent mode for local jobs.
@@ -639,7 +643,8 @@ class VariableMgrDistributedReplicated(VariableMgr):
 
   def get_devices(self):
     return self.benchmark_cnn.raw_devices
-
+  def get_variables_to_save(self):
+    return tf.local_variables()
 
 def sum_grad_and_var_all_reduce(grad_and_vars, devices):
   # Note that each grad_and_vars looks like the following:


### PR DESCRIPTION
firstly , the _eval function currently not support the mode of 'variable_update=parameter_server' and 'variable_update=distributed_replicated' ,and there will be some mistakes while using the mode of 'replicated' to restore parameters from the checkpoint file that created by training with 'variable_update=parameter_server|distributed_replicated' ,so I changed the 'target' to fix it .

secondly ,while variable_update='distributed_replicated' ,the result of eval function looks not correct. I found that the set of tf.global_variables have no parameters while restoring checkpoint , and even in training ,tf.global_variables() only contained 190+ parameters(these parameters were copied from local_variables and only trainable variables) ,without 'batchnorm/gamma' ,'batchnorm/moving_mean' and 'batchnorm/moving_variance' ,so I changed the code to store/restore parammeters from/to the tf.local_variables and it worked.