### PR TITLE
Add __init__.py file under tf_cnn_benchmarks folder so that python ca…

### DIFF
--- a/scripts/Dockerfile.tf_cnn_benchmarks
+++ b/scripts/Dockerfile.tf_cnn_benchmarks
@@ -3,6 +3,7 @@ FROM tensorflow/tensorflow:nightly-gpu
 RUN apt-get update && apt-get install -y python-pip && pip install google-cloud
 RUN mkdir ./tf_cnn_benchmarks/
 COPY tf_cnn_benchmarks/*.py ./tf_cnn_benchmarks/
+RUN touch tf_cnn_benchmarks/__init__.py
 RUN mkdir ./util/
 COPY util/ ./util/
 ENTRYPOINT ["python", "-m", "tf_cnn_benchmarks.tf_cnn_benchmarks"]


### PR DESCRIPTION
…n find the module