### PR TITLE
Migrate deprecated functions in favour of core

### DIFF
--- a/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py
+++ b/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py
@@ -624,7 +624,7 @@ class BenchmarkCNN(object):
       execution_barrier = self.add_sync_queues_and_barrier(
           'execution_barrier_', [])
 
-    global_step = tf.contrib.framework.get_global_step()
+    global_step = tf.train.get_global_step()
     with tf.device(self.global_step_device):
       with tf.control_dependencies([main_fetch_group]):
         fetches['inc_global_step'] = global_step.assign_add(1)
@@ -769,7 +769,7 @@ class BenchmarkCNN(object):
     use_synthetic_gpu_images = self.image_preprocessor is None
 
     with tf.device(self.global_step_device):
-      global_step = tf.contrib.framework.get_or_create_global_step()
+      global_step = tf.train.get_or_create_global_step()
 
     # Build the processing and model for the worker.
     with tf.device(self.cpu_device):


### PR DESCRIPTION
Both `tf.contrib.framework.get_global_step` and `tf.contrib.framework.get_or_create_global_step` has been migrated to `tf.train`, and current TF master warns about the deprecation of the `tf.contrib` versions in next release. 

`tf.train.get_global_step` is available at least from v1.0, and `tf.train.get_or_create_global_step` is introduced in v1.1.