### PR TITLE
Fix python argparse issue when running with --help

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -190,7 +190,7 @@ _DEFAULT_PARAMS = {
                    'Useful for testing the benchmark script, as this allows '
                    'distributed mode to be run on a single machine. For '
                    'example, if there are two tasks, each can be allocated '
-                   '~40% of the memory on a single machine'),
+                   '~40%% of the memory on a single machine'),
     'use_tf_layers':
         _ParamSpec('boolean', True,
                    'If True, use tf.layers for neural network layers. This '


### PR DESCRIPTION
When running python tf_cnn_benchmarks.py --help I was getting
TypeError: %o format: a number is required, not dict

argparse has an issue to recognize single % in the help message
of an argument. The solution is to double the percent character.