### PR TITLE
from six.moves import xrange for line 511

### DIFF
--- a/scripts/tf_cnn_benchmarks/allreduce.py
+++ b/scripts/tf_cnn_benchmarks/allreduce.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import collections as pycoll
 import re
 
-from six.moves import xrange
+from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
 from tensorflow.contrib import nccl

--- a/scripts/tf_cnn_benchmarks/allreduce.py
+++ b/scripts/tf_cnn_benchmarks/allreduce.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import collections as pycoll
 import re
 
+from six.moves import xrange
 import tensorflow as tf
 
 from tensorflow.contrib import nccl


### PR DESCRIPTION
__xrange()__ was removed from Python 3 in favor of __range()__.  @reedwm 