### PR TITLE
Set different seed for different Horovod workers

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -1523,8 +1523,14 @@ class BenchmarkCNN(object):
 
   def _build_model(self):
     """Build the TensorFlow graph."""
-    tf.set_random_seed(self.params.tf_random_seed)
-    np.random.seed(4321)
+    # Adjust seed so different workers start read different input files.
+    if self.params.variable_update == 'horovod':
+        import horovod.tensorflow as hvd
+        seed_adjustment = hvd.rank()
+    else:
+        seed_adjustment = 0
+    tf.set_random_seed(self.params.tf_random_seed + seed_adjustment)
+    np.random.seed(4321 + seed_adjustment)
     phase_train = not (self.params.eval or self.params.forward_only)
 
     log_fn('Generating model')


### PR DESCRIPTION
Improves convergence.  Due to fixed seed, multiple workers on the same host would end up reading the same data.  See https://github.com/uber/horovod/issues/173