### PR TITLE
Remove codepath when TF version is under 1.1.

### DIFF
--- a/scripts/tf_cnn_benchmarks/preprocessing.py
+++ b/scripts/tf_cnn_benchmarks/preprocessing.py
@@ -344,16 +344,8 @@ def train_image(image_buffer,
     # This resizing operation may distort the images because the aspect
     # ratio is not respected.
     image_resize_method = get_image_resize_method(resize_method, batch_position)
-    if cnn_util.tensorflow_version() >= 11:
-      distorted_image = tf.image.resize_images(
+    distorted_image = tf.image.resize_images(
           distorted_image, [height, width],
-          image_resize_method,
-          align_corners=False)
-    else:
-      distorted_image = tf.image.resize_images(
-          distorted_image,
-          height,
-          width,
           image_resize_method,
           align_corners=False)
     # Restore the shape since the dynamic slice based upon the bbox_size loses


### PR DESCRIPTION
We currently require at least TF 1.6 so that codepath is never used.