### PR TITLE
disable data prefetch when MKL is used

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -1206,7 +1206,10 @@ class BenchmarkCNN(object):
 
     self.image_preprocessor = self.get_image_preprocessor()
     self.datasets_use_prefetch = (
-        self.params.datasets_use_prefetch and not self.params.mkl and
+        self.params.datasets_use_prefetch and
+        # TODO(rohanj): Figure out why --datasets_use_prefetch freezes on the
+        # CPU.
+        not self.params.device.lower() == 'cpu' and
         self.image_preprocessor.supports_datasets())
     self.init_global_step = 0
 

--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -1206,7 +1206,7 @@ class BenchmarkCNN(object):
 
     self.image_preprocessor = self.get_image_preprocessor()
     self.datasets_use_prefetch = (
-        self.params.datasets_use_prefetch and
+        self.params.datasets_use_prefetch and not self.params.mkl and
         self.image_preprocessor.supports_datasets())
     self.init_global_step = 0
 


### PR DESCRIPTION
The current version of benchmark will hang if MKL is used and data-prefetch is enabled. The PR is to disable data-prefetch when MKL is used.