### PR TITLE
Fix bug: `distributed_all_reduce` will error cause less params.

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -2183,7 +2183,9 @@ class BenchmarkCNN(object):
       # Build the per-worker image processing
       function_buffering_resources = data_utils.build_prefetch_image_processing(
           self.model.get_image_size(), self.model.get_image_size(),
-          self.batch_size // len(self.devices), self.cpu_device, self.params,
+          self.batch_size // len(self.devices),
+          len(self.devices), self.image_preprocessor.parse_and_preprocess,
+          self.cpu_device, self.params,
           self.devices, self.dataset)
 
       # Build the per-worker model replica.


### PR DESCRIPTION
`distributed_all_reduce` mode will error cause `build_prefetch_image_processing` inside `_build_model_single_session_with_dataset_prefetching` has less param.