### PR TITLE
Read specific checkpoint and control max_to_keep

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn_test.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn_test.py
@@ -23,7 +23,6 @@ import re
 
 import mock
 from mock import patch
-
 import numpy as np
 import tensorflow as tf
 from google.protobuf import text_format


### PR DESCRIPTION
Enables the following:

- set max number of checkpoints to keep with `max_ckpt_to_keep`
- If the full path to a checkpoint is passed that will be evaled.  Currently the assumption is `train_dir` is to a directory with checkpoints and the latest checkpoint is evaled.