### PR TITLE
Pass session config with run_params for BenchmarkLogger

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -1508,6 +1508,7 @@ class BenchmarkCNN(object):
           'data_format': self.params.data_format,
           'rewrite_config': self.rewriter_config,
           'optimizer': self.params.optimizer,
+          'session_config': create_config_proto(self.params),
       }
       # TODO(scottzhu): tf_cnn_benchmark might execute several times with
       # different param setting on the same box. This will cause the run file to


### PR DESCRIPTION
Add session_config to run_params so that BenchmarkLogger can use it when querying gpu devices. Relies on https://github.com/tensorflow/models/pull/5299 to function properly and addresses #249.