### PR TITLE
Fix a bug of the formular for caculating the speed_mean

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -807,7 +807,7 @@ def get_perf_timing_str(speed_mean, speed_uncertainty, speed_jitter, scale=1):
 def get_perf_timing(batch_size, step_train_times, scale=1):
   times = np.array(step_train_times)
   speeds = batch_size / times
-  speed_mean = scale * batch_size / np.mean(times)
+  speed_mean = scale * np.mean(batch_size / times)
   speed_uncertainty = np.std(speeds) / np.sqrt(float(len(speeds)))
   speed_jitter = 1.4826 * np.median(np.abs(speeds - np.median(speeds)))
   return speed_mean, speed_uncertainty, speed_jitter


### PR DESCRIPTION
Fix the bug of the formula.  Line 810 in 4c7b09a
Please refer to the issue 56
https://github.com/tensorflow/benchmarks/issues/270

 speed_mean = scale * batch_size / np.mean(times) 

The speed_mean should be calculate as this:
speed_mean = scale * np.mean(batch_size / times)
We want to caculate the mean of the speed instead of  dividing batch_size by the mean training time.

For example:
batch_size = 32
step_train_times = [0.32, 0.33, 0.36]
times = np.array(step_train_times)
speed_mean = batch_size / np.mean(times)
print(speed_mean)
95.04950495049505

speed_mean = np.mean(batch_size / times)
95.28619528619528
