### PR TITLE
Create single device if only one nvme drive exists.

### DIFF
--- a/perfzero/lib/perfzero/common/device_utils_test.py
+++ b/perfzero/lib/perfzero/common/device_utils_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Tests data disk config module."""
+"""Tests device_utils module."""
 from __future__ import print_function
 
 import unittest

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -53,7 +53,7 @@ class SetupRunner(object):
     # Set up the raid array.
     if self.gce_nvme_raid == 'all':
       devices = device_utils.get_nvme_devices()
-      device_utils.create_gce_nvme_raid(self.data_dir, devices)
+      device_utils.create_drive_from_devices(self.data_dir, devices)
 
     # Check out git repos
     git_repos = self._get_git_repos()


### PR DESCRIPTION
Adds logic that if only one device exists just format and mount.  Also renamed methods to not say nvme as much as given a list of devices the methods likely can create an array out of anything or format and mount a regular drive.  

Also tweaked wording on the unit test.  I would have added more unit tests but we need to break out a few things or the test ends up as a pile of mocks.  