### PR TITLE
Support running all methods in a class with filter:bench.*

### DIFF
--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 
 import importlib
 import os
-import sys
+import re
 import time
 import uuid
 
@@ -33,27 +33,48 @@ class BenchmarkRunner(object):
   def __init__(self, config=None):
     project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
     workspace_dir = os.path.join(project_dir, 'workspace')
-    site_packages_dir = os.path.join(workspace_dir, 'site-packages')
-    auth_token_path = os.path.join(workspace_dir,
-                                   'auth_tokens/benchmark_upload_gce.json')
+    self.site_packages_dir = os.path.join(workspace_dir, 'site-packages')
+    self.auth_token_path = os.path.join(workspace_dir,
+                                        'auth_tokens/benchmark_upload_gce.json')
     self.output_root_dir = os.path.join(workspace_dir, 'output')
     self.config = config
-    """Setup environment before executing tests."""
-    utils.setup_python_path(site_packages_dir, config.python_paths_str)
-    utils.active_gcloud_service(auth_token_path)
+    self._setup()
+
+  def _setup(self):
+    """Sets up environment for tests to run."""
+    utils.setup_python_path(self.site_packages_dir,
+                            self.config.python_paths_str)
+    utils.active_gcloud_service(self.auth_token_path)
     utils.make_dir_if_not_exist(self.output_root_dir)
 
   def run_benchmark(self):
     """Run tests."""
-    for benchmark_method in self.config.benchmark_methods_str.split(','):
+
+    filter_prefix = 'filter:'
+    # Check if filter or list of exact methods to execute.
+    methods_str = self.config.benchmark_methods_str
+    if methods_str.startswith(filter_prefix):
+      # Gets test object only to fine methods to execute.
+      match_filter = methods_str[len(filter_prefix):]
+      print('match_filter:{}'.format(match_filter))
+      filter_class = self._instantiate_benchmark_class('/dev/null')
+      benchmark_methods = self._return_methods_to_execute(filter_class,
+                                                          match_filter)
+    else:
+      benchmark_methods = self.config.benchmark_methods_str.split(',')
+    self._exec_benchmarks(benchmark_methods)
+
+  def _exec_benchmarks(self, benchmark_methods):
+    """Executes all benchmark methods."""
+    print('Methods to execute:{}'.format(','.join(benchmark_methods)))
+    for benchmark_method in benchmark_methods:
       uid = str(uuid.uuid4())
       output_dir = os.path.join(self.output_root_dir, uid)
       utils.make_dir_if_not_exist(output_dir)
-
       class_instance = self._instantiate_benchmark_class(output_dir)
       class_method_name = '{}.{}'.format(class_instance.__class__.__name__,
                                          benchmark_method)
-
+      print('Start Benchmark: {}'.format(class_method_name))
       start_time = time.time()
       # Run benchmark method
       getattr(class_instance, benchmark_method)()
@@ -107,6 +128,14 @@ class BenchmarkRunner(object):
     instance.oss_report_object = benchmark_result.BenchmarkResult()
     return instance
 
+  def _return_methods_to_execute(self, class_, match_filter):
+    """Returns methods to execute on class based on filter passed."""
+    found_methods = []
+    possible_methods = dir(class_)
+    for method in possible_methods:
+      if re.match(match_filter, method):
+        found_methods.append(method)
+    return found_methods
 
 if __name__ == '__main__':
 

--- a/perfzero/lib/benchmark_test.py
+++ b/perfzero/lib/benchmark_test.py
@@ -17,11 +17,12 @@ from __future__ import print_function
 
 import os
 import sys
+import types
 import unittest
 
-import perfzero.report.benchmark_result as benchmark_result
 import benchmark
-from mock import Mock
+import mock
+import perfzero.report.benchmark_result as benchmark_result
 
 
 class TestTestRunner(unittest.TestCase):
@@ -34,14 +35,64 @@ class TestTestRunner(unittest.TestCase):
         del os.environ[envar]
     super(TestTestRunner, self).tearDown()
 
-  @unittest.skip('')
-  def test_load_test_class(self):
-    """Tests ok_to_run not finding existing processes."""
-    sys.modules['foo.fake'] = Mock()
-    os.environ['ROGUE_TEST_CLASS'] = 'foo.fake.TestClass'
-    os.environ['ROGUE_TEST_METHODS'] = 'TestMethod'
-    os.environ['ROGUE_PYTHON_PATH'] = 'models'
-    benchmark_runner = benchmark.BenchmarkRunner()
-    class_ = benchmark_runner._load_test_class('/dev/null')
+  @mock.patch('benchmark.BenchmarkRunner._setup')
+  def test_load_test_class(self, mock_setup):
+    """Test loading module and test class."""
+
+    # foo.fake is not found unless foo and fake are mocked.
+    sys.modules['foo'] = mock.Mock()
+    sys.modules['foo.fake'] = mock.Mock()
+    config = mock.Mock()
+    config.test_class_str = 'foo.fake.TestClass'
+    config.python_paths_str = None
+    benchmark_runner = benchmark.BenchmarkRunner(config)
+    class_ = benchmark_runner._instantiate_benchmark_class('/dev/null')
     self.assertIsInstance(class_.oss_report_object,
                           type(benchmark_result.BenchmarkResult()))
+    mock_setup.assert_called()
+
+  @mock.patch('benchmark.BenchmarkRunner._setup')
+  def test_method_filter(self, _):
+    """Tests returning methods on a class based on a filter."""
+    regex_filter = 'bench.*'
+    config = mock.Mock()
+    config.python_paths_str = None
+    benchmark_runner = benchmark.BenchmarkRunner(config)
+    mock_test_class = mock.Mock()
+    mock_test_class.benchmark_test = 'foo'
+    methods = benchmark_runner._return_methods_to_execute(mock_test_class,
+                                                          regex_filter)
+    self.assertEqual('benchmark_test', methods[0])
+
+  @mock.patch('benchmark.BenchmarkRunner._exec_benchmarks')
+  @mock.patch('benchmark.BenchmarkRunner._setup')
+  def test_run_benchmarks_filter(self, _, exec_bench_mock):
+    """Test run benchmarks with filters argument."""
+    test_class = mock.Mock()
+    test_class.benchmark_foo = 'foo'
+    module = mock.Mock()
+    sys.modules['new_foo'] = module
+    module.TestClass.return_value = test_class
+    config = mock.Mock()
+    config.test_class_str = 'new_foo.TestClass'
+    config.benchmark_methods_str = 'filter:bench'
+    benchmark_runner = benchmark.BenchmarkRunner(config)
+
+    benchmark_runner.run_benchmark()
+    arg0 = exec_bench_mock.call_args[0][0]
+    self.assertEqual('benchmark_foo', arg0[0])
+
+  @mock.patch('benchmark.BenchmarkRunner._exec_benchmarks')
+  @mock.patch('benchmark.BenchmarkRunner._setup')
+  def test_run_benchmarks_list_of_methods(self, _, exec_bench_mock):
+    """Test run benchmarks with list of methods."""
+    module = mock.Mock()
+    sys.modules['new_foo'] = module
+    config = mock.Mock()
+    config.test_class_str = 'new_foo.TestClass'
+    config.benchmark_methods_str = 'benchmark_1,benchmark_2'
+    benchmark_runner = benchmark.BenchmarkRunner(config)
+
+    benchmark_runner.run_benchmark()
+    arg0 = exec_bench_mock.call_args[0][0]
+    self.assertEqual(config.benchmark_methods_str.split(','), arg0)


### PR DESCRIPTION
This adds looking for the prefix 'filter:' in the list of methods to execute in a given class.  If the method names starts with 'filter:' it is treated as a regex to be run against the class to determine which methods to use using re.match.

One requirement I had is I want a user to be able to easily specify a single test to run.  re.match makes that hard so I had to go with a prefix to indicate a non-exact match.  I would like to revisit this in the final interface as it is clunky.  I had two requirments and I might just be short sighted:
-  ability to pass regex to pick a group of tests to run or just all
- ability for users to just pass a single test to run and not have it end up doing starts_with and running multiple tests.

I also fixed benchmark_tests and expanded it.