### PR TITLE
change the number of kerners to the settings of the alexnet paper.

### DIFF
--- a/scripts/tf_cnn_benchmarks/models/alexnet_model.py
+++ b/scripts/tf_cnn_benchmarks/models/alexnet_model.py
@@ -37,9 +37,9 @@ class AlexnetModel(model.CNNModel):
 
   def add_inference(self, cnn):
     # Note: VALID requires padding the images by 3 in width and height
-    cnn.conv(64, 11, 11, 4, 4, 'VALID')
+    cnn.conv(96, 11, 11, 4, 4, 'VALID')
     cnn.mpool(3, 3, 2, 2)
-    cnn.conv(192, 5, 5)
+    cnn.conv(256, 5, 5)
     cnn.mpool(3, 3, 2, 2)
     cnn.conv(384, 3, 3)
     cnn.conv(384, 3, 3)


### PR DESCRIPTION
The number of alexnet kernels in the benchmark differs from the number described in the alexnet paper.
Is there a special reason?
I changed the number of kernels to the configuration of alexnet paper.