### PR TITLE
Update PerfZero benchmark execution summary

### DIFF
--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -118,13 +118,13 @@ class BenchmarkRunner(object):
           setup_info = json.load(f)
         benchmark_result = report_utils.build_benchmark_result(raw_benchmark_result)
         execution_summary = report_utils.build_execution_summary(
-            execution_timestamp, execution_id, self.config.test_env_str,
+            execution_timestamp, execution_id,
             self.config.ml_framework_build_label_str,
             self.config.execution_label_str, self.config.platform_name_str,
             self.config.system_name_str, self.config.output_gcs_url_str,
             benchmark_result, self.config.get_env_vars(), setup_info, has_exception)
         report_utils.upload_execution_summary(
-            self.config.bigquery_project_name_str,
+            self.config.bigquery_project_name_str, self.config.test_env_str,
             self.config.bigquery_dataset_table_name_str, execution_summary,
             raw_benchmark_result)
         logging.info('Benchmark execution completed with summary:\n %s',

--- a/perfzero/lib/benchmark_test.py
+++ b/perfzero/lib/benchmark_test.py
@@ -27,26 +27,11 @@ import mock
 class TestBenchmarkRunner(unittest.TestCase):
 
   @mock.patch('benchmark.BenchmarkRunner._setup')
-  def test_load_benchmark_class(self, mock_setup):
-    """Test loading module and test class."""
-
-    # foo.fake is not found unless foo and fake are mocked.
-    sys.modules['foo'] = mock.Mock()
-    sys.modules['foo.fake'] = mock.Mock()
-    config = mock.Mock()
-    config.benchmark_class_str = 'foo.fake.TestClass'
-    config.python_paths_str = None
-    benchmark_runner = benchmark.BenchmarkRunner(config)
-    class_instance = benchmark_runner._instantiate_benchmark_class('/dev/null')
-    mock_setup.assert_called()
-
-  @mock.patch('benchmark.BenchmarkRunner._setup')
   def test_get_benchmark_methods_filter(self, mock_setup):
     """Tests returning methods on a class based on a filter."""
     config = mock.Mock()
     config.python_paths_str = None
-    config.benchmark_methods_str = 'filter:bench.*'
-    config.benchmark_class_str = 'new_foo.BenchmarkClass'
+    config.benchmark_methods_maybe_filter = ['new_foo.BenchmarkClass.filter:bench.*']
     benchmark_runner = benchmark.BenchmarkRunner(config)
 
     mock_benchmark_class = mock.Mock()
@@ -59,16 +44,15 @@ class TestBenchmarkRunner(unittest.TestCase):
     methods = benchmark_runner._get_benchmark_methods()
 
     self.assertEqual(1, len(methods))
-    self.assertEqual('benchmark_method_1', methods[0])
+    self.assertEqual('new_foo.BenchmarkClass.benchmark_method_1', methods[0])
 
   @mock.patch('benchmark.BenchmarkRunner._setup')
   def test_get_benchmark_methods_exact_match(self, mock_setup):
     """Tests returning methods on a class based on a filter."""
     config = mock.Mock()
     config.python_paths_str = None
-    config.benchmark_methods_str = 'benchmark_method_1,benchmark_method_2'
-    config.benchmark_class_str = 'new_foo.BenchmarkClass'
+    config.benchmark_methods_maybe_filter = ['new_foo.BenchmarkClass.benchmark_method_1','new_foo.BenchmarkClass.benchmark_method_2']
     benchmark_runner = benchmark.BenchmarkRunner(config)
 
     methods = benchmark_runner._get_benchmark_methods()
-    self.assertEqual(['benchmark_method_1', 'benchmark_method_2'], methods)
+    self.assertEqual(['new_foo.BenchmarkClass.benchmark_method_1', 'new_foo.BenchmarkClass.benchmark_method_2'], methods)

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -22,10 +22,13 @@ class PerfZeroConfig(object):
   """Creates and contains config for PerfZero."""
 
   def __init__(self, mode):
-    if mode == 'env' and 'PERFZERO_BENCHMARK_METHODS' in os.environ:
-      self.benchmark_methods_str = self._get_env_var(
+    if mode == 'env' and 'PERFZERO_BENCHMARK_CLASS' in os.environ:
+      benchmark_methods_str = self._get_env_var(
           'PERFZERO_BENCHMARK_METHODS')
-      self.benchmark_class_str = self._get_env_var('PERFZERO_BENCHMARK_CLASS')
+      benchmark_class_str = self._get_env_var('PERFZERO_BENCHMARK_CLASS')
+      self.benchmark_methods_maybe_filter = []
+      for benchmark_method in benchmark_methods_str.split(','):
+        self.benchmark_methods_maybe_filter.append(benchmark_class_str + '.' + benchmark_method)
       self.platform_name_str = self._get_env_var('PERFZERO_PLATFORM_NAME')
       self.system_name_str = self._get_env_var('PERFZERO_SYSTEM_NAME')
       self.test_env_str = self._get_env_var('PERFZERO_TEST_ENV')
@@ -35,16 +38,44 @@ class PerfZeroConfig(object):
                                                   False)
       self.gcs_downloads_str = self._get_env_var('PERFZERO_GCS_DOWNLOADS',
                                                  False)
-      self.bigquery_table_name_str = self._get_env_var(
-          'PERFZERO_BIGQUERY_TABLE_NAME')
+      self.bigquery_dataset_table_name_str = self._get_env_var(
+          'PERFZERO_BIGQUERY_TABLE_NAME', False)
       self.bigquery_project_name_str = self._get_env_var(
-          'PERFZERO_BIGQUERY_PROJECT_NAME')
+          'PERFZERO_BIGQUERY_PROJECT_NAME', False)
       self.dockerfile_path_str = self._get_env_var('PERFZERO_DOCKERFILE_PATH',
-                                                   False,
-                                                   'docker/Dockerfile')
-    elif mode == 'env' and 'PERFZERO_BENCHMARK_METHODS' not in os.environ:
-      self.benchmark_methods_str = self._get_env_var('ROGUE_TEST_METHODS')
-      self.benchmark_class_str = self._get_env_var('ROGUE_TEST_CLASS')
+                                                   False, 'docker/Dockerfile')
+      self.ml_framework_build_label_str = self._get_env_var(
+          'PERFZERO_ML_FRAMEWORK_BUILD_LABEL', False)
+      self.execution_label_str = self._get_env_var('PERFZERO_EXECUTION_LABEL', False)
+    elif mode == 'env' and 'PERFZERO_PLATFORM_NAME' in os.environ:
+      self.benchmark_methods_maybe_filter = []
+      for key in os.environ.keys():
+        if key.startswith('PERFZERO_BENCHMARK_METHOD'):
+          self.benchmark_methods_maybe_filter.append(os.environ[key])
+      self.platform_name_str = self._get_env_var('PERFZERO_PLATFORM_NAME')
+      self.system_name_str = self._get_env_var('PERFZERO_SYSTEM_NAME')
+      self.test_env_str = self._get_env_var('PERFZERO_TEST_ENV')
+      self.python_path_str = self._get_env_var('PERFZERO_PYTHON_PATH')
+      self.git_repos_str = self._get_env_var('PERFZERO_GIT_REPOS')
+      self.output_gcs_url_str = self._get_env_var('PERFZERO_OUTPUT_GCS_URL',
+                                                  False)
+      self.gcs_downloads_str = self._get_env_var('PERFZERO_GCS_DOWNLOADS',
+                                                 False)
+      self.bigquery_dataset_table_name_str = self._get_env_var(
+          'PERFZERO_BIGQUERY_TABLE_NAME', False)
+      self.bigquery_project_name_str = self._get_env_var(
+          'PERFZERO_BIGQUERY_PROJECT_NAME', False)
+      self.dockerfile_path_str = self._get_env_var('PERFZERO_DOCKERFILE_PATH',
+                                                   False, 'docker/Dockerfile')
+      self.ml_framework_build_label_str = self._get_env_var(
+          'PERFZERO_ML_FRAMEWORK_BUILD_LABEL', False)
+      self.execution_label_str = self._get_env_var('PERFZERO_EXECUTION_LABEL', False)
+    elif mode == 'env' and 'ROGUE_TEST_CLASS' in os.environ:
+      benchmark_methods_str = self._get_env_var('ROGUE_TEST_METHODS')
+      benchmark_class_str = self._get_env_var('ROGUE_TEST_CLASS')
+      self.benchmark_methods_maybe_filter = []
+      for benchmark_method in benchmark_methods_str.split(','):
+        self.benchmark_methods_maybe_filter.append(benchmark_class_str + '.' + benchmark_method)
       self.platform_name_str = self._get_env_var(
           'ROGUE_PLATFORM', False, default='unknown')
       self.system_name_str = self._get_env_var(
@@ -59,21 +90,26 @@ class PerfZeroConfig(object):
           'ROGUE_GCS_DOWNLOADS', False, default='')
       self.bigquery_project_name_str = self._get_env_var(
           'ROGUE_REPORT_PROJECT', False, default='')
-      self.bigquery_table_name_str = 'benchmark_results.result'
-
+      self.bigquery_dataset_table_name_str = 'benchmark_results.result'
+      self.ml_framework_build_label_str = None
+      self.execution_label_str = None
       if not self.bigquery_project_name_str:
         self.bigquery_project_name_str = 'google.com:tensorflow-performance'
-        self.bigquery_table_name_str = 'benchmark_results_dev.result'
-
+        self.bigquery_dataset_table_name_str = 'benchmark_results_dev.result'
     elif mode == 'mock':
       pass
+
+  def get_env_vars(self):
+    env_vars = {}
+    for key in os.environ.keys():
+      if key.startswith('PERFZERO_') or key.startswith('ROGUE_'):
+        env_vars[key] = os.environ[key]
+    return env_vars
 
   def _get_env_var(self, key, is_required=True, default=None):
     if key in os.environ and os.environ[key]:
       return os.environ[key]
-
     if is_required:
       raise ValueError(
           'Environment variable {} needs to be defined'.format(key))
-
     return default

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -22,6 +22,10 @@ class PerfZeroConfig(object):
   """Creates and contains config for PerfZero."""
 
   def __init__(self, mode):
+    # In this mode, PERFZERO_BENCHMARK_CLASS and PERFZERO_BENCHMARK_METHODS
+    # are used to dertermine the benchmark methods we want to execute. This mode is
+    # deprecated because it constraints one perfzero execution to only run
+    # benchmark methods from one class
     if mode == 'env' and 'PERFZERO_BENCHMARK_CLASS' in os.environ:
       benchmark_methods_str = self._get_env_var(
           'PERFZERO_BENCHMARK_METHODS')
@@ -47,6 +51,11 @@ class PerfZeroConfig(object):
       self.ml_framework_build_label_str = self._get_env_var(
           'PERFZERO_ML_FRAMEWORK_BUILD_LABEL', False)
       self.execution_label_str = self._get_env_var('PERFZERO_EXECUTION_LABEL', False)
+    # In this mode, environment variables with prefix PERFZERO_BENCHMARK_METHOD
+    # are used to dertermine the benchmark methods we want to execute. The
+    # value of these environment variables encodes both the benchmark class and
+    # benchmark method name. And it allows user to run arbitrary combination of
+    # benchmark methods in one perfzero execution
     elif mode == 'env' and 'PERFZERO_PLATFORM_NAME' in os.environ:
       self.benchmark_methods_maybe_filter = []
       for key in os.environ.keys():
@@ -70,6 +79,9 @@ class PerfZeroConfig(object):
       self.ml_framework_build_label_str = self._get_env_var(
           'PERFZERO_ML_FRAMEWORK_BUILD_LABEL', False)
       self.execution_label_str = self._get_env_var('PERFZERO_EXECUTION_LABEL', False)
+    # In this mode, ROGUE_TEST_CLASS and ROGUE_TEST_METHODS
+    # are used to dertermine the benchmark methods we want to execute. This mode is
+    # deprecated because the variable name should start with PERFZERO
     elif mode == 'env' and 'ROGUE_TEST_CLASS' in os.environ:
       benchmark_methods_str = self._get_env_var('ROGUE_TEST_METHODS')
       benchmark_class_str = self._get_env_var('ROGUE_TEST_CLASS')

--- a/perfzero/lib/perfzero/report_utils.py
+++ b/perfzero/lib/perfzero/report_utils.py
@@ -31,8 +31,8 @@ from six import u as unicode  # pylint: disable=W0622
 import perfzero.utils as utils
 
 
-def upload_execution_summary(bigquery_project_name, bigquery_table_name,
-                             execution_summary):
+def upload_execution_summary(bigquery_project_name, bigquery_dataset_table_name,
+                             execution_summary, raw_benchmark_result):
   """Upload benchmark summary.
 
   Note: Using stream=False has a 1000 per day insert limit per table. Using
@@ -45,58 +45,95 @@ def upload_execution_summary(bigquery_project_name, bigquery_table_name,
   mapped to BYTE.
   """
 
-  credentials = google.auth.default()[0]
-
-  sql = """INSERT into {} (result_id, test_id, test_harness,
-           test_environment, result_info, user, timestamp, system_info,
-           test_info, extras)
-             VALUES
-           (@result_id, @test_id, @test_harness, @test_environment,
-           @result_info, @user, @timestamp, @system_info, @test_info, @extras)
-           """.format(bigquery_table_name)
-
-  entry = _translate_summary_into_old_bigquery_format(execution_summary,
-                                                      credentials)
-  logging.info('Bigquery entry is {}'.format(json.dumps(entry, indent=2)))
-
   if not bigquery_project_name:
     logging.info(
-        'Skipped uploading benchmark result to bigquery because bigquery project id is not set.'
+        'Skipped uploading benchmark result to bigquery because bigquery table name is not set.'
     )
     return
 
+  if not bigquery_dataset_table_name:
+    logging.info(
+        'Skipped uploading benchmark result to bigquery because bigquery project name is not set.'
+    )
+    return
+
+  credentials = google.auth.default()[0]
+  dataset_name = bigquery_dataset_table_name.split('.')[0]
+  table_name = bigquery_dataset_table_name.split('.')[1]
   client = bigquery.Client(
       project=bigquery_project_name, credentials=credentials)
-  conn = connect(client=client)
-  cursor = conn.cursor()
-  cursor.execute(sql, parameters=entry)
-  conn.commit()
-  cursor.close()
-  conn.close()
-  logging.info(
-      'Uploaded benchmark result to the table {} of the bigquery project {}.'
-      .format(bigquery_table_name, bigquery_project_name))
+
+  bigquery_input = _translate_summary_into_old_bigquery_format(
+      execution_summary, raw_benchmark_result, credentials)
+  logging.info('Bigquery input is {}'.format(json.dumps(bigquery_input, indent=2)))
+
+  table_ref = client.dataset(dataset_name).table(table_name)
+  table_obj = client.get_table(table_ref)
+  errors = client.insert_rows(table_obj, [bigquery_input])
+
+  benchmark_summary_input = {}
+  for key, value in execution_summary.items():
+    if type(value) == dict:
+      benchmark_summary_input[key] = unicode(json.dumps(value))
+    else:
+      benchmark_summary_input[key] = unicode(value)
+  logging.info('Bigquery input for benchmark_summary table is {}'.format(
+    json.dumps(benchmark_summary_input, indent=2)))
+
+  if dataset_name == 'benchmark_results_dev':
+    table_ref = client.dataset('perfzero_dev').table('benchmark_summary')
+    table_obj = client.get_table(table_ref)
+    errors.extend(client.insert_rows(table_obj, [benchmark_summary_input]))
+  elif dataset_name == 'benchmark_results':
+    table_ref = client.dataset('perfzero').table('benchmark_summary')
+    table_obj = client.get_table(table_ref)
+    errors.extend(client.insert_rows(table_obj, [benchmark_summary_input]))
+
+  #sql = """INSERT into {} (result_id, test_id, test_harness,
+  #         test_environment, result_info, user, timestamp, system_info,
+  #         test_info, extras)
+  #           VALUES
+  #         (@result_id, @test_id, @test_harness, @test_environment,
+  #         @result_info, @user, @timestamp, @system_info, @test_info, @extras)
+  #         """.format(bigquery_dataset_table_name)
+  #
+  #conn = connect(client=client)
+  #cursor = conn.cursor()
+  #cursor.execute(sql, parameters=bigquery_input)
+  #conn.commit()
+  #cursor.close()
+  #conn.close()
+
+  if len(errors) > 0:
+    logging.error(
+        'Failed to upload benchmark result to bigquery due to errors {}'.format(
+            errors))
+  else:
+    logging.info(
+        'Uploaded benchmark result to the table {} of the bigquery project {}.'
+        .format(bigquery_dataset_table_name, bigquery_project_name))
 
 
-def _translate_summary_into_old_bigquery_format(execution_summary, credentials):
+def _translate_summary_into_old_bigquery_format(
+    execution_summary, raw_benchmark_result, credentials):
   entry = {}
   entry['result_id'] = unicode(execution_summary['execution_id'])
-  entry['test_id'] = unicode(execution_summary['benchmark_result']['name'])
-  entry['test_harness'] = unicode('perfzero')
+  entry['test_id'] = unicode(raw_benchmark_result['name'])
+  entry['test_harness'] = unicode(
+      execution_summary['benchmark_info']['harness_name'])
   entry['test_environment'] = unicode(
       execution_summary['benchmark_info']['test_environment'])
 
   result_info_list = []
   result_info = {}
-  result_info[
-      'result'] = execution_summary['benchmark_result']['wall_time'] * 1000
+  result_info['result'] = raw_benchmark_result['wall_time'] * 1000
   result_info['result_type'] = 'total_time'
   result_info['result_unit'] = 'ms'
   result_info_list.append(result_info)
   # Extra fields whose value is a json-formatted string
-  if 'accuracy' in execution_summary['benchmark_result']['extras']:
-    attributes = json.loads(execution_summary['benchmark_result']['extras']
-                            ['accuracy']['string_value'])
+  if 'accuracy' in raw_benchmark_result['extras']:
+    attributes = json.loads(
+        raw_benchmark_result['extras']['accuracy']['string_value'])
     result_info = {}
     result_info['result'] = attributes['value']
     result_info['result_type'] = 'quality'
@@ -107,33 +144,33 @@ def _translate_summary_into_old_bigquery_format(execution_summary, credentials):
       else:
         result_info['result_status'] = 'FAILED'
     result_info_list.append(result_info)
-  if 'accuracy_top_5' in execution_summary['benchmark_result']['extras']:
-    attributes = json.loads(execution_summary['benchmark_result']['extras']
-                            ['accuracy']['string_value'])
+  if 'accuracy_top_5' in raw_benchmark_result['extras']:
+    attributes = json.loads(
+        raw_benchmark_result['extras']['accuracy']['string_value'])
     result_info = {}
     result_info['result'] = attributes['value']
     result_info['result_type'] = 'quality'
     result_info['result_unit'] = 'top_5'
     result_info_list.append(result_info)
-  if 'top_1_train_accuracy' in execution_summary['benchmark_result']['extras']:
-    attributes = json.loads(execution_summary['benchmark_result']['extras']
-                            ['top_1_train_accuracy']['string_value'])
+  if 'top_1_train_accuracy' in raw_benchmark_result['extras']:
+    attributes = json.loads(
+        raw_benchmark_result['extras']['top_1_train_accuracy']['string_value'])
     result_info = {}
     result_info['result'] = attributes['value']
     result_info['result_type'] = 'quality'
     result_info['result_unit'] = 'top_1_train_accuracy'
     result_info_list.append(result_info)
-  if 'exp_per_second' in execution_summary['benchmark_result']['extras']:
-    attributes = json.loads(execution_summary['benchmark_result']['extras']
-                            ['exp_per_second']['string_value'])
+  if 'exp_per_second' in raw_benchmark_result['extras']:
+    attributes = json.loads(
+        raw_benchmark_result['extras']['exp_per_second']['string_value'])
     result_info = {}
     result_info['result'] = attributes['value']
     result_info['result_type'] = 'exp_per_second'
     result_info['result_unit'] = 'exp_per_second'
     result_info_list.append(result_info)
-  if 'avg_exp_per_second' in execution_summary['benchmark_result']['extras']:
-    attributes = json.loads(execution_summary['benchmark_result']['extras']
-                            ['avg_exp_per_second']['string_value'])
+  if 'avg_exp_per_second' in raw_benchmark_result['extras']:
+    attributes = json.loads(
+        raw_benchmark_result['extras']['avg_exp_per_second']['string_value'])
     result_info = {}
     result_info['result'] = attributes['value']
     result_info['result_type'] = 'avg_exp_per_second'
@@ -141,17 +178,17 @@ def _translate_summary_into_old_bigquery_format(execution_summary, credentials):
     result_info_list.append(result_info)
 
   # Extra fields whose value is double
-  if 'top_1_accuracy' in execution_summary['benchmark_result']['extras']:
+  if 'top_1_accuracy' in raw_benchmark_result['extras']:
     result_info = {}
-    result_info['result'] = execution_summary['benchmark_result']['extras'][
-        'top_1_accuracy']['double_value']
+    result_info['result'] = raw_benchmark_result['extras']['top_1_accuracy'][
+        'double_value']
     result_info['result_type'] = 'quality'
     result_info['result_unit'] = 'top_1'
     result_info_list.append(result_info)
-  if 'top_5_accuracy' in execution_summary['benchmark_result']['extras']:
+  if 'top_5_accuracy' in raw_benchmark_result['extras']:
     result_info = {}
-    result_info['result'] = execution_summary['benchmark_result']['extras'][
-        'top_5_accuracy']['double_value']
+    result_info['result'] = raw_benchmark_result['extras']['top_5_accuracy'][
+        'double_value']
     result_info['result_type'] = 'quality'
     result_info['result_unit'] = 'top_5'
     result_info_list.append(result_info)
@@ -171,9 +208,10 @@ def _translate_summary_into_old_bigquery_format(execution_summary, credentials):
   system_info = {}
   system_info['platform'] = execution_summary['system_info']['platform_name']
   system_info['platform_type'] = execution_summary['system_info']['system_name']
-  system_info['accel_type'] = execution_summary['system_info']['gpu_model']
+  system_info['accel_type'] = execution_summary['system_info'][
+      'accelerator_model']
   system_info['accel_driver_version'] = execution_summary['system_info'][
-      'gpu_driver_version']
+      'accelerator_driver_version']
   system_info['cpu_cores'] = execution_summary['system_info']['cpu_core_count']
   system_info['cpu_type'] = execution_summary['system_info']['cpu_model']
   system_info['cpu_sockets'] = execution_summary['system_info'][
@@ -181,14 +219,14 @@ def _translate_summary_into_old_bigquery_format(execution_summary, credentials):
   entry['system_info'] = unicode(json.dumps(system_info))
 
   test_info = {}
-  test_info['framework'] = execution_summary['ml_framework_info']['framework']
+  test_info['framework'] = execution_summary['ml_framework_info']['name']
   test_info['channel'] = execution_summary['ml_framework_info']['channel']
   test_info['build_type'] = execution_summary['ml_framework_info']['build_type']
-  test_info['accel_cnt'] = execution_summary['system_info']['gpu_count']
+  test_info['accel_cnt'] = execution_summary['system_info']['accelerator_count']
   test_info['framework_version'] = execution_summary['ml_framework_info'][
       'version']
   test_info['framework_describe'] = execution_summary['ml_framework_info'][
-      'git_version']
+      'build_version']
   test_info['model'] = 'unknown'
   test_info['cmd'] = 'unknown'
   entry['test_info'] = unicode(json.dumps(test_info))
@@ -200,49 +238,84 @@ def _translate_summary_into_old_bigquery_format(execution_summary, credentials):
   return entry
 
 
-#def upload_with_stream_mode(client, dataset, table, row):
-#  """Uploads row to BigQuery via streaming interface."""
-#  table_ref = client.dataset(dataset).table(table)
-#  table_obj = client.get_table(table_ref)  # API request
-#  errors = client.insert_rows(table_obj, [row])
+def build_benchmark_result(raw_benchmark_result):
+  # Convert benchmark result from the test_log.proto format to the format defined by PerfZero
+  benchmark_result = {}
+  benchmark_result['name'] = raw_benchmark_result['name']
+  benchmark_result['wall_time'] = raw_benchmark_result['wall_time']
+
+  succeeded = True
+  metrics = []
+  for name in raw_benchmark_result['extras']:
+    entry = {}
+    entry['name'] = name
+
+    if 'double_value' in raw_benchmark_result['extras'][name]:
+      entry['value'] = raw_benchmark_result['extras'][name]['double_value']
+    else:
+      attributes = json.loads(
+          raw_benchmark_result['extras'][name]['string_value'])
+      entry['value'] = attributes['value']
+      if 'succeeded' in attributes:
+        entry['succeeded'] = attributes['succeeded']
+        succeeded = succeeded and attributes['succeeded']
+      if 'description' in attributes:
+        entry['description'] = attributes['description']
+    metrics.append(entry)
+
+  benchmark_result['succeeded'] = succeeded
+  benchmark_result['metrics'] = metrics
+
+  return benchmark_result
 
 
-def build_execution_summary(execution_id, test_environment, platform_name,
-                            system_name, output_url, benchmark_result):
+def build_execution_summary(execution_timestamp, execution_id, test_environment,
+                            ml_framework_build_label, execution_label,
+                            platform_name, system_name, output_gcs_url,
+                            benchmark_result, env_vars, setup_info, has_exception):
   import tensorflow as tf
 
   benchmark_info = {}
   benchmark_info['test_environment'] = test_environment
-  benchmark_info['date_time'] = unicode(
-      datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S'))
-  benchmark_info['output_url'] = output_url
+  benchmark_info['harness_name'] = 'perfzero'
+  benchmark_info['has_exception'] = has_exception
+  if execution_label:
+    benchmark_info['execution_label'] = execution_label
+  if output_gcs_url:
+    benchmark_info['output_url'] = '{}/{}/'.format(output_gcs_url, execution_id)
+  benchmark_info['env_vars'] = env_vars
 
   ml_framework_info = {}
-  ml_framework_info['framework'] = 'tensorflow'
+  ml_framework_info['name'] = 'tensorflow'
   ml_framework_info['version'] = tf.__version__
   # tf.__git_version__ in Python3 has format b'version_string'
   if tf.__git_version__[0] == 'b':
-    ml_framework_info['git_version'] = tf.__git_version__[2:-1]
+    ml_framework_info['build_version'] = tf.__git_version__[2:-1]
   else:
-    ml_framework_info['git_version'] = tf.__git_version__
+    ml_framework_info['build_version'] = tf.__git_version__
   ml_framework_info['channel'] = 'NIGHTLY'
   ml_framework_info['build_type'] = 'OTB'
+
+  if ml_framework_build_label:
+    ml_framework_info['build_label'] = ml_framework_build_label
 
   system_info = {}
   gpu_info = utils.get_gpu_info()
   system_info['platform_name'] = platform_name
   system_info['system_name'] = system_name
-  system_info['gpu_driver_version'] = gpu_info['gpu_driver_version']
-  system_info['gpu_model'] = gpu_info['gpu_model']
-  system_info['gpu_count'] = gpu_info['gpu_count']
+  system_info['accelerator_driver_version'] = gpu_info['gpu_driver_version']
+  system_info['accelerator_model'] = gpu_info['gpu_model']
+  system_info['accelerator_count'] = gpu_info['gpu_count']
   system_info['cpu_model'] = utils.get_cpu_name()
   system_info['cpu_core_count'] = utils.get_cpu_core_count()
   system_info['cpu_socket_count'] = utils.get_cpu_socket_count()
 
   execution_summary = {}
   execution_summary['execution_id'] = execution_id
+  execution_summary['execution_timestamp'] = execution_timestamp
   execution_summary['benchmark_result'] = benchmark_result
   execution_summary['benchmark_info'] = benchmark_info
+  execution_summary['setup_info'] = setup_info
   execution_summary['ml_framework_info'] = ml_framework_info
   execution_summary['system_info'] = system_info
 

--- a/perfzero/lib/setup_test.py
+++ b/perfzero/lib/setup_test.py
@@ -43,7 +43,7 @@ class TestSetupRunner(unittest.TestCase):
     repo_list = setup_runner._get_git_repos()
     actual_repo_0 = repo_list[0]
     actual_repo_1 = repo_list[1]
-    self.assertEqual(repo_0[0], actual_repo_0['local_path'])
+    self.assertEqual(repo_0[0], actual_repo_0['dir_name'])
     self.assertEqual(repo_0[1], actual_repo_0['url'])
     self.assertEqual(repo_0[2], actual_repo_0['branch'])
-    self.assertEqual(repo_1[3], actual_repo_1['sha_hash'])
+    self.assertEqual(repo_1[3], actual_repo_1['git_hash'])

--- a/perfzero/scripts/setup_env.sh
+++ b/perfzero/scripts/setup_env.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-#export PERFZERO_BENCHMARK_METHODS=unit_test
-#export PERFZERO_BENCHMARK_CLASS=official.resnet.estimator_cifar_benchmark.EstimatorCifar10BenchmarkTests
-export PERFZERO_BENCHMARK_METHODS=benchmark_fake_1gpu_gpuparams
-export PERFZERO_BENCHMARK_CLASS=leading_indicators_test.Resnet50Benchmarks
+#export PERFZERO_BENCHMARK_METHOD=leading_indicators_test.Resnet50Benchmarks.benchmark_fake_1gpu_gpuparams
+#export PERFZERO_BENCHMARK_METHODS=benchmark_fake_1gpu_gpuparams
+#export PERFZERO_BENCHMARK_CLASS=leading_indicators_test.Resnet50Benchmarks
+export PERFZERO_BENCHMARK_METHODS=unit_test
+export PERFZERO_BENCHMARK_CLASS=official.resnet.estimator_cifar_benchmark.EstimatorCifar10BenchmarkTests
 export PERFZERO_PLATFORM_NAME=workstation
 export PERFZERO_SYSTEM_NAME=z420
 export PERFZERO_TEST_ENV=local
 export PERFZERO_PYTHON_PATH=models,benchmarks/scripts/tf_cnn_benchmarks
-export PERFZERO_GIT_REPOS="models;https://github.com/tensorflow/models.git,benchmarks;https://github.com/tensorflow/benchmarks.git"
+export PERFZERO_GIT_REPOS="https://github.com/tensorflow/models.git,https://github.com/tensorflow/benchmarks.git"
 export PERFZERO_OUTPUT_GCS_URL=gs://tf-performance/test-results
-export PERFZERO_GCS_DOWNLOADS="cifar10_data;gs://tf-perf-imagenet-uswest1/tensorflow/cifar10_data/*,gs://tf-perf-imagenet-uswest1/tensorflow/fake_tf_record_data"
+export PERFZERO_GCS_DOWNLOADS="gs://tf-perf-imagenet-uswest1/tensorflow/cifar10_data/"
 export PERFZERO_BIGQUERY_TABLE_NAME="benchmark_results_dev.result"
 export PERFZERO_BIGQUERY_PROJECT_NAME="google.com:tensorflow-performance"


### PR DESCRIPTION
This patch makes the following improvements:

- Use bigquery stream API to upload data
- Improve field names of the json-formatted execution summary
- Export git hash for dependent site packages to bigquery
- Export environment variables used during benchmark setup and execution respectively
- Prevent one benchmark execution failure from affecting other benchmark execution
- Upload benchmark execution summary to the new bigquery table
- Allow user to specify git repository url without specifying install folder
- Allow user to specify benchmark class and benchmark method name in one environment variable