### PR TITLE
Add flag --profiler_enabled_time to support profiler

### DIFF
--- a/perfzero/README.md
+++ b/perfzero/README.md
@@ -19,9 +19,10 @@ regression.
 
 PerfZero makes it easy to execute the pre-defined test by consolidating the
 docker image build, GPU driver installation, Tensorflow installation, benchmark
-library checkout, data download, system statistics collection, benchmark
-metrics collection and so on into 2 to 3 commands. This allows developer to focus
-on investigating the issue rather than setting up the test environment.
+library checkout, data download, system statistics collection, benchmark metrics
+collection, profiler data collection and so on into 2 to 3 commands. This allows
+developer to focus on investigating the issue rather than setting up the test
+environment.
 
 2) For user who wants to track the performance change of Tensorflow for a
 variety of setup (e.g. GPU model, cudnn version, Tensorflow version)
@@ -97,6 +98,15 @@ test a branch from a pull request without changing your existing workspace.
 repo with the specified git_branch at the specified git_hash to the local folder
 with specified folder name.
 
+5) Use `--profiler_enabled_time=start_time:end_time` to collect profiler data
+during period `[start_time, end_time)` after the benchmark method execution
+starts. Skip `end_time` in the flag value to collect data until the end of
+benchmark method execution. Run `tensorboard
+--logdir=perfzero/workspace/output/${execution_id}` or `python3 -m
+tensorboard.main --logdir=perfzero/workspace/output/${execution_id}` to open
+Tensorboard server. If PerfZero is executed on a remote machine,
+run `ssh -L 6006:127.0.0.1:6006 remote_ip` before opening `http://localhost:6006`
+in your browser to access the Tensorboard UI.
 
 ## Understand benchmark summary
 

--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -136,10 +136,14 @@ class BenchmarkRunner(object):
             benchmark_result_file_path_prefix,
             benchmark_class_name,
             benchmark_method_name)
+
+        scheduler = utils.schedule_profiler_events(
+            self.config.profiler_enabled_time_str, output_dir)
         # Run benchmark method
         logging.info('Start benchmark: %s', benchmark_method)
         getattr(class_instance, benchmark_method_name)()
         logging.info('End benchmark: %s', benchmark_method)
+        utils.cancel_profiler_events(scheduler, output_dir)
         # Read and build benchmark results
         raw_benchmark_result = utils.read_benchmark_result(benchmark_result_file_path)  # pylint: disable=line-too-long
         # Explicitly overwrite the name to be the full path to benchmark method
@@ -182,6 +186,11 @@ class BenchmarkRunner(object):
       self.benchmark_execution_time[benchmark_method] = {}
       self.benchmark_execution_time[benchmark_method]['benchmark_time'] = upload_timestamp - start_timestamp  # pylint: disable=line-too-long
       self.benchmark_execution_time[benchmark_method]['upload_time'] = time.time() - upload_timestamp  # pylint: disable=line-too-long
+
+      if self.config.profiler_enabled_time_str:
+        relative_output_dir = output_dir[output_dir.find('benchmark'):]
+        print('\nExecute the command below to start tensorboard server using the collected profiler data:\n'
+              'tensorboard --logdir={}\n'.format(relative_output_dir))
 
     print('Benchmark execution time in seconds by operation:\n {}'.format(
         json.dumps(self.benchmark_execution_time, indent=2)))

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -114,6 +114,15 @@ def add_parser_arguments(parser):
       help='''The log files, gcs token file and git repositories will be generated and downloaded under
       directory path_to_perfzero/${workspace}
       ''')
+  parser.add_argument(
+      '--profiler_enabled_time',
+      default=None,
+      type=str,
+      help='''A string of format begin_time_1:end_time_1,begin_time_2:end_time_2,.... PerfZero will start to collect profiler
+      data ${begin_time} sec after benchmark method execution starts. The data collection continues for ${end_time - begin_time}
+      sec or until the benchmark method execution finishes, whichever occurs first. If ${end_time} is not explicitly
+      specified, it is assumed to be MAX_LONG.
+      ''')
 
 
 class PerfZeroConfig(object):
@@ -138,6 +147,7 @@ class PerfZeroConfig(object):
       self.python_path_str = flags.python_path
       self.workspace = flags.workspace
       self.force_update = flags.force_update
+      self.profiler_enabled_time_str = flags.profiler_enabled_time
 
       if not flags.benchmark_methods:
         logging.warn('No benchmark method is specified by --benchmark_methods')

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -17,8 +17,22 @@ from __future__ import print_function
 
 import logging
 import os
+import sched
 import subprocess
 import sys
+import threading
+import time
+import traceback
+
+exit_event = threading.Event()
+
+
+def sleep_until_exit(timeout):
+  start_time = time.time()
+  cur_time = time.time()
+  while cur_time - start_time < timeout and not exit_event.is_set():
+    time.sleep(min(1, timeout + start_time - cur_time))
+    cur_time = time.time()
 
 
 def checkout_git_repos(git_repos, force_update):
@@ -143,7 +157,6 @@ def download_from_gcs(gcs_downloads):
 
 def maybe_upload_to_gcs(local_dir, output_gcs_url):
   if not output_gcs_url:
-    logging.info('Skipped uploading output because output_gcs_url is not set.')
     return
   run_commands(['gsutil -m cp -r {} {}'.format(local_dir, output_gcs_url)])
   logging.info('Uploaded data from local directory %s to gcs %s',
@@ -274,3 +287,100 @@ def read_benchmark_result(benchmark_result_file_path):
 
     return json_format.MessageToDict(
         benchmark_entries, preserving_proto_field_name=True)['entry'][0]
+
+
+def cancel_profiler_events(scheduler, output_dir):
+  """Stop scheduler and save profiler data if any event is cancelled.
+
+  Args:
+    scheduler: the scheduler instance
+    output_dir: log directory to place the profiler data
+  """
+
+  event_canceled = False
+  for event in scheduler.queue:
+    try:
+      scheduler.cancel(event)
+      event_canceled = True
+    except ValueError:
+      # This is OK because the event may have been just canceled
+      pass
+
+  # Signal the scheduler thread to stop sleeping
+  exit_event.set()
+  # Cancelled events must include _stop_and_save_profiler(). Make sure we save
+  # the profiler data before for the execution.
+  if event_canceled:
+    _stop_and_save_profiler(output_dir)
+
+
+def _start_profiler():
+  from tensorflow.python.eager import profiler  # pylint: disable=g-import-not-at-top
+
+  try:
+    logging.info('Starting profiler')
+    profiler.start()
+  except Exception:  # pylint: disable=W0703
+    logging.error('Profiler failed to start due to error:\n %s',
+                  traceback.format_exc())
+
+
+def _stop_and_save_profiler(output_dir):
+  """Stop profiler and save profiler data.
+
+  Args:
+    output_dir: log directory to place the profiler data
+  """
+  from tensorflow.python.eager import profiler  # pylint: disable=g-import-not-at-top
+
+  try:
+    profiler_data_dir = os.path.join(output_dir, 'profiler_data')
+    logging.info('Stopping profiler and saving data to dir %s',
+                 profiler_data_dir)
+    make_dir_if_not_exist(profiler_data_dir)
+    result = profiler.stop()
+    with open(os.path.join(profiler_data_dir, 'local.trace'), 'wb') as f:
+      f.write(result)
+  except Exception:  # pylint: disable=W0703
+    logging.error('Profiler failed to stop due to error:\n %s',
+                  traceback.format_exc())
+
+
+def schedule_profiler_events(profiler_enabled_time_str, output_dir):
+  """Schedule start/stop event for profiler if instructed by config.
+
+  Args:
+    profiler_enabled_time_str: the value of the config --profiler_enabled_time
+    output_dir: log directory to place the profiler data
+
+  Returns:
+    The scheduler instance, or None if nothing is scheduled
+  """
+  scheduler = sched.scheduler(time.time, sleep_until_exit)
+  if not profiler_enabled_time_str:
+    return scheduler
+
+  last_end_time = -1
+  for time_str in profiler_enabled_time_str.split(','):
+    begin_time = int(time_str.split(':')[0].strip())
+    end_time_str = time_str.split(':')[1].strip() if ':' in time_str else None
+    end_time = int(end_time_str) if end_time_str else 365 * 24 * 60 * 60
+    if begin_time <= last_end_time:
+      raise ValueError('begin_time {} is no larger than the last end_time {}'.format(begin_time, last_end_time))  # pylint: disable=line-too-long
+    if end_time <= begin_time:
+      raise ValueError('end_time {} is no larger than begin_time {}'.format(end_time, begin_time))  # pylint: disable=line-too-long
+    scheduler.enter(begin_time, 1, _start_profiler, ())
+    scheduler.enter(end_time, 1, _stop_and_save_profiler,
+                    argument=(output_dir,))
+    last_end_time = end_time
+
+  threading.Thread(target=scheduler.run).start()
+  return scheduler
+
+
+def print_thread_stacktrace():
+  print('Here is the stacktrace for all threads:')
+  thread_names = {t.ident: t.name for t in threading.enumerate()}
+  for thread_id, frame in sys._current_frames().items():  # pylint: disable=protected-access
+    print('Thread {}'.format(thread_names.get(thread_id, thread_id)))
+    traceback.print_stack(frame)


### PR DESCRIPTION
This patch adds the flag --profiler_enabled_time to instruct PerfZero to collect profiler data that can be analyzed by Tensorboard. See README and `benchmark.py --help` for more information about its usage.