### PR TITLE
Add flag --root_data_dir for user to specify custom data directory

### DIFF
--- a/perfzero/lib/perfzero/report_utils.py
+++ b/perfzero/lib/perfzero/report_utils.py
@@ -107,7 +107,7 @@ def build_benchmark_result(raw_benchmark_result, has_exception):
 
   succeeded = not has_exception
   metrics = []
-  for name in raw_benchmark_result['extras']:
+  for name in raw_benchmark_result.get('extras', {}):
     entry = {}
     entry['name'] = name
 

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -21,30 +21,20 @@ import logging
 import os
 import time
 
+import perfzero.perfzero_config as perfzero_config
 import perfzero.utils as utils
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-  parser.add_argument(
-      '--dockerfile_path',
-      default='docker/Dockerfile',
-      type=str,
-      help='''Build the docker image using docker file located at
-      path_to_perfzero/{dockerfile_path}''')
-  parser.add_argument(
-      '--workspace',
-      default='workspace',
-      type=str,
-      help='''The gcs token file will be downloaded under directory
-      path_to_perfzero/{workspace}''')
+  perfzero_config.add_setup_parser_arguments(parser)
   FLAGS, unparsed = parser.parse_known_args()
 
   logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
                       level=logging.DEBUG)
   if unparsed:
-    logging.warn('Arguments %s are not recognized', unparsed)
+    logging.warning('Arguments %s are not recognized', unparsed)
 
   setup_execution_time = {}
   project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -53,8 +43,7 @@ if __name__ == '__main__':
   # Download gcloud auth token. Remove this operation in the future when
   # docker in Kokoro can accesss the GCP metadata server
   start_time = time.time()
-  utils.download_from_gcs([{'gcs_url': 'gs://tf-performance/auth_tokens',
-                            'local_path': os.path.join(workspace_dir, 'auth_tokens')}])  # pylint: disable=line-too-long
+  utils.active_gcloud_service(FLAGS.gcloud_key_file_url, workspace_dir, download_only=True)  # pylint: disable=line-too-long
   setup_execution_time['download_token'] = time.time() - start_time
 
   start_time = time.time()

--- a/scripts/tf_cnn_benchmarks/leading_indicators_test.py
+++ b/scripts/tf_cnn_benchmarks/leading_indicators_test.py
@@ -30,9 +30,9 @@ import sys
 
 from absl import flags
 from absl.testing import absltest  # pylint: disable=unused-import
-import tensorflow as tf
 import benchmark_cnn
 from platforms import util as platforms_util
+import tensorflow as tf
 
 flags.DEFINE_integer('num_batches', None,
                      'number of batches to run, excluding warmup')
@@ -41,15 +41,26 @@ flags.DEFINE_integer('num_batches', None,
 class BenchmarkBase(tf.test.Benchmark):
   """Base class for all benchmarks in this file."""
 
-  def __init__(self, output_dir=None):
+  def __init__(self, output_dir=None, root_data_dir=None):
+    """Base class for all benchmarks in this file.
+
+    Args:
+      output_dir: directory where to output e.g. log files
+      root_data_dir: directory under which to look for dataset
+    """
+
     # Load default values if the benchmark is not run with absl.app.run()
     if not flags.FLAGS.is_parsed():
       flags.FLAGS.mark_as_parsed()
 
     self.fake_data_dir = os.path.join(platforms_util.get_test_data_dir(),
                                       'fake_tf_record_data')
-    self.data_dir = ('/readahead/200M/placer/prod/home/distbelief/'
-                     'imagenet-tensorflow/imagenet-2012-tfrecord')
+
+    if root_data_dir is None:
+      self.data_dir = ('/readahead/200M/placer/prod/home/distbelief/'
+                       'imagenet-tensorflow/imagenet-2012-tfrecord')
+    else:
+      self.data_dir = os.path.join(root_data_dir, 'imagenet')
     self.output_dir = output_dir
 
   def _run_benchmark(self, params):


### PR DESCRIPTION
This patch makes the following improvements to improve PerfZero usability:
    
- Added flag --root_data_dir for user to specify custom data directory
- Added flag --data_downloads for user to download data using http
- Added flag --gcloud_key_file_url for user to specify custom gcloud key file
- Deprecated flag --gcs_downloads in favor of --data_downloads

Currently PerfZero requires all dataset files required by the benchmark method to be under directory `/data`. This may requires a bit more work from user to move the dataset files if these files are not already under directory `/data`. Addition of  the flag `--root_data_dir` allows user to the specify the directory that contains the dataset files

Currently PerfZero only allow user to specify gcs url to download data. The addition of the flag `--data_downloads` allows PerfZero to download data from http or https directly, e.g. https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz. This is convenient for users who are not able to download dataset from Google Cloud Storage.

Currently PerfZero hardcodes the path to gcloud credential file as `gs://tf-performance/auth_tokens/benchmark_upload_gce.json`. This is not accessible by most users. The addition of the flag `--gcloud_key_file_url` allows user to specify custom credential file or just skip the use of the gcloud credential file.


