### PR TITLE
Allow user to specify dockerfile_path as either absolute path or be reelative to user's pwd

### DIFF
--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -25,7 +25,7 @@ def add_setup_parser_arguments(parser):
       '--dockerfile_path',
       default='docker/Dockerfile',
       type=str,
-      help='''Build the docker image using docker file located at path_to_perfzero/{dockerfile_path}
+      help='''Build the docker image using docker file located at the specified path.
       ''')
   parser.add_argument(
       '--workspace',

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -54,7 +54,10 @@ if __name__ == '__main__':
 
   # Create docker image
   start_time = time.time()
-  dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
+  dockerfile_path = FLAGS.dockerfile_path
+  if not os.path.exists(dockerfile_path):
+    # Fall back to the deprecated approach if the user-specified dockerfile_path does not exist
+    dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
   docker_tag = 'temp/tf-gpu'
   cmd = 'docker build --pull -t {} - < {}'.format(docker_tag, dockerfile_path)
   utils.run_commands([cmd])


### PR DESCRIPTION
Currently the docker file path is determined as path_to_perfzero/${dockerfile_path} where dockerfile_path is the value from the flag --dockerfile_path. However, most users would expect the value of the `--dockerfile_path` to be used directly as the docker file path, which is also easier to use thanks to the auto-complete feature provided by the commonly-used terminal.

This patch makes the change to make the API easier to use.