### PR TITLE
Allow user to specify pip package installed in the PerfZero docker image

### DIFF
--- a/perfzero/README.md
+++ b/perfzero/README.md
@@ -46,7 +46,7 @@ Here are instructions for users who want to run benchmark method using PerfZero.
 
 ## Build docker image
 
-The command below builds the docker image named `temp/tf-gpu` which contains the
+The command below builds the docker image named `perfzero/tensorflow` which contains the
 libraries (e.g. Tensorflow) needed for benchmark.
 
 ```
@@ -65,7 +65,7 @@ The command below executes the benchmark method specified by `--benchmark_method
 ```
 export ROOT_DATA_DIR=/data
 
-nvidia-docker run -it --rm -v $(pwd):/workspace -v $ROOT_DATA_DIR:$ROOT_DATA_DIR temp/tf-gpu \
+nvidia-docker run -it --rm -v $(pwd):/workspace -v $ROOT_DATA_DIR:$ROOT_DATA_DIR perfzero/tensorflow \
 python3 /workspace/benchmarks/perfzero/lib/benchmark.py \
 --gcloud_key_file_url="" \
 --git_repos="https://github.com/tensorflow/models.git" \
@@ -93,9 +93,10 @@ test a branch from a pull request without changing your existing workspace.
 
 3) Use `--git_repos="git_url;git_branch;git_hash"` to checkout a git repo with
 the specified git_branch at the specified git_hash to the local folder with the
-specified folder name.  Specify the flag once for each repository you want to
-checkout.  Note that the value of the flag `--git_repos` is wrapped by the 
-quotation mark `"` so that `;` will not be interpreted by the bash as the end of the command.
+specified folder name. **Note that** the value of the flag `--git_repos` is
+wrapped by the quotation mark `"` so that `;` will not be interpreted by the
+bash as the end of the command. Specify the flag once for each repository you
+want to checkout.
 
 5) Use `--profiler_enabled_time=start_time:end_time` to collect profiler data
 during period `[start_time, end_time)` after the benchmark method execution

--- a/perfzero/docker/Dockerfile
+++ b/perfzero/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM tensorflow/tensorflow:nightly-gpu-py3
 
 WORKDIR /root
 ENV HOME /root
+ARG tensorflow_pip_spec="tf-nightly-gpu"
 
 # Add google-cloud-sdk to the source list
 RUN apt-get install -y curl
@@ -37,7 +38,7 @@ RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
 RUN pip3 install --upgrade setuptools google-api-python-client google-cloud google-cloud-bigquery
 RUN pip3 install wheel absl-py
-RUN pip3 install --upgrade --force-reinstall tf-nightly-gpu
+RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
@@ -3,6 +3,7 @@
 #  - Installs requirements.txt for tensorflow/models
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
+ARG tensorflow_pip_spec="tf-nightly-gpu"
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -64,7 +65,7 @@ RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery
 RUN pip3 install wheel absl-py
-RUN pip3 install --upgrade --force-reinstall tf-nightly-gpu
+RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -3,6 +3,7 @@
 #  - Installs requirements.txt for tensorflow/models
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
+ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -64,7 +65,7 @@ RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery
 RUN pip3 install wheel absl-py
-RUN pip3 install --upgrade --force-reinstall tf-nightly-gpu-2.0-preview
+RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 RUN pip3 install tfds-nightly
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -23,15 +23,17 @@ def add_setup_parser_arguments(parser):
   """Add arguments to the parser used by the setup.py."""
   parser.add_argument(
       '--dockerfile_path',
-      default='docker/Dockerfile',
+      default='docker/Dockerfile_ubuntu_1804_tf_v1',
       type=str,
-      help='''Build the docker image using docker file located at the specified path.
+      help='''Build the docker image using docker file located at the ${pwd}/${dockerfile_path} if
+      it exists, where ${pwd} is user's current work directory. Otherwise, build
+      the docker image using the docker file located at path_to_perfzero/${dockerfile_path}.
       ''')
   parser.add_argument(
       '--workspace',
       default='workspace',
       type=str,
-      help='''The gcloud key file will be downloaded under directory path_to_perfzero/{workspace}
+      help='''The gcloud key file will be downloaded under directory path_to_perfzero/${workspace}
       ''')
   parser.add_argument(
       '--gcloud_key_file_url',
@@ -51,6 +53,14 @@ def add_setup_parser_arguments(parser):
       type=str,
       help='If set to non-empty string, create raid 0 array with devices at the directory specified by the flag --root_data_dir'
       )
+  parser.add_argument(
+      '--tensorflow_pip_spec',
+      default=None,
+      type=str,
+      help='''The tensorflow pip package specfication. The format can be either ${package_name}, or ${package_name}==${package_version}.
+      Example values include tf-nightly-gpu, and tensorflow==1.12.0. If it is specified, the corresponding tensorflow pip package/version
+      will be installed. Otherwise, the default tensorflow pip package specified in the docker file will be installed.
+      ''')
 
 
 def add_benchmark_parser_arguments(parser):
@@ -210,7 +220,7 @@ class PerfZeroConfig(object):
       self.profiler_enabled_time_str = flags.profiler_enabled_time
 
       if not flags.benchmark_methods:
-        logging.warning('No benchmark method is specified by --benchmark_methods')
+        logging.warning('No benchmark method is specified by --benchmark_methods')  # pylint: disable=line-too-long
 
       if flags.bigquery_project_name and not flags.bigquery_dataset_table_name:
         raise ValueError('--bigquery_project_name is specified but --bigquery_dataset_table_name is not')  # pylint: disable=line-too-long

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -56,10 +56,16 @@ if __name__ == '__main__':
   start_time = time.time()
   dockerfile_path = FLAGS.dockerfile_path
   if not os.path.exists(dockerfile_path):
-    # Fall back to the deprecated approach if the user-specified dockerfile_path does not exist
+    # Fall back to the deprecated approach if the user-specified
+    # dockerfile_path does not exist
     dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
-  docker_tag = 'temp/tf-gpu'
-  cmd = 'docker build --pull -t {} - < {}'.format(docker_tag, dockerfile_path)
+  docker_tag = 'perfzero/tensorflow'
+  if FLAGS.tensorflow_pip_spec:
+    cmd = 'docker build --no-cache --pull -t {} --build-arg tensorflow_pip_spec={} - < {}'.format(  # pylint: disable=line-too-long
+        docker_tag, FLAGS.tensorflow_pip_spec, dockerfile_path)
+  else:
+    cmd = 'docker build --no-cache --pull -t {} - < {}'.format(docker_tag, dockerfile_path)
+
   utils.run_commands([cmd])
   logging.info('Built docker image with tag %s', docker_tag)
   setup_execution_time['build_docker'] = time.time() - start_time


### PR DESCRIPTION
This patch made the following changes:

- Added flag --tensorflow_pip_spec to setup.py for user to specify the tensorflow pip package and optionally version as well.
- setup.py will always use flag --no-cache when building the docker image
- Changed the name of the docker image built by setup.py from temp/tf-gpu to perfzero/tensorflow
- Changed default docker file to docker/Dockerfile_ubuntu_1804_tf_v1