### PR TITLE
Report maximum rss and vms in the benchmark summary

### DIFF
--- a/perfzero/lib/cloud_manager.py
+++ b/perfzero/lib/cloud_manager.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+#
 # Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/perfzero/lib/perfzero/process_info_tracker.py
+++ b/perfzero/lib/perfzero/process_info_tracker.py
@@ -1,0 +1,87 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Keep track of process information such as maximum memory usage with a separate thread."""
+
+from __future__ import absolute_import
+
+import json
+import logging
+import os
+import sched
+import threading
+import time
+import traceback
+import psutil
+
+
+class ProcessInfoTracker(object):
+  """Keep track of process information such as maximum memory usage with separate thread."""
+
+  def __init__(self, output_dir):
+    self.process_info_log = open(os.path.join(output_dir, 'process_info.log'), 'w')  # pylint: disable=line-too-long
+    self.scheduler = sched.scheduler(time.time, time.sleep)
+    self.process_info = {}
+    self.process_info['max_rss'] = 0
+    self.process_info['max_vms'] = 0
+    self.process_info['max_cpu_percent'] = 0
+    self.exit_event = threading.Event()
+    self.last_exception = None
+    self.start_time = None
+
+  def start(self):
+    self.start_time = time.time()
+    self.scheduler.enter(1, 1, self._update_process_info)  # pylint: disable=no-value-for-parameter
+    threading.Thread(target=self.scheduler.run).start()
+    logging.info('Started process information tracker.')
+
+  def stop(self):
+    self.exit_event.set()
+    self.process_info_log.flush()
+    logging.info('Stopped process information tracker.')
+
+    if self.last_exception is not None:
+      raise self.last_exception  # pylint: disable=raising-bad-type
+
+    return dict(self.process_info)
+
+  def _update_process_info(self):
+    """Read and update process info using background thread every 1 second."""
+    try:
+      p = psutil.Process(os.getpid())
+      memory_info = p.memory_info()
+      # This is a blocking call which takes 0.1 second.
+      # This affects the interval # at which the metrics are reported
+      cpu_percent = p.cpu_percent(interval=0.1)
+
+      self.process_info['max_rss'] = max(self.process_info['max_rss'], memory_info.rss)  # pylint: disable=line-too-long
+      self.process_info['max_vms'] = max(self.process_info['max_vms'], memory_info.vms)  # pylint: disable=line-too-long
+      self.process_info['max_cpu_percent'] = max(self.process_info['max_cpu_percent'], cpu_percent)  # pylint: disable=line-too-long
+
+      entry = {}
+      entry['time'] = time.time() - self.start_time
+      entry['rss'] = memory_info.rss
+      entry['vms'] = memory_info.vms
+      entry['cpu_percent'] = cpu_percent
+      self.process_info_log.write(json.dumps(entry) + '\n')
+      if not self.exit_event.is_set():
+        # Schedule the next event to be run after 1 second
+        self.scheduler.enter(1, 1, self._update_process_info)  # pylint: disable=no-value-for-parameter
+    except Exception as e:  # pylint: disable=W0703
+      logging.error('Process info tracker failed due to error:\n %s',
+                    traceback.format_exc())
+      self.last_exception = e
+
+

--- a/perfzero/lib/perfzero/report_utils.py
+++ b/perfzero/lib/perfzero/report_utils.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import json
 import logging
 import perfzero.utils as utils
+import psutil
 
 from six import u as unicode  # pylint: disable=W0622
 
@@ -134,7 +135,7 @@ def build_execution_summary(execution_timestamp, execution_id,
                             ml_framework_build_label, execution_label,
                             platform_name, system_name, output_gcs_url,
                             benchmark_result, env_vars, flags,
-                            site_package_info, has_exception):
+                            site_package_info, process_info, has_exception):
   """Builds summary of the execution."""
   # Avoids module not found during setup phase when tf is not installed yet.
   # pylint: disable=C6204
@@ -175,7 +176,8 @@ def build_execution_summary(execution_timestamp, execution_id,
   system_info['accelerator_model'] = gpu_info['gpu_model']
   system_info['accelerator_count'] = gpu_info['gpu_count']
   system_info['cpu_model'] = utils.get_cpu_name()
-  system_info['cpu_core_count'] = utils.get_cpu_core_count()
+  system_info['physical_cpu_count'] = psutil.cpu_count(logical=False)
+  system_info['logical_cpu_count'] = psutil.cpu_count(logical=True)
   system_info['cpu_socket_count'] = utils.get_cpu_socket_count()
 
   execution_summary = {}
@@ -186,5 +188,7 @@ def build_execution_summary(execution_timestamp, execution_id,
   execution_summary['setup_info'] = {}
   execution_summary['ml_framework_info'] = ml_framework_info
   execution_summary['system_info'] = system_info
+  if process_info:
+    execution_summary['process_info'] = process_info
 
   return execution_summary

--- a/perfzero/lib/perfzero/tensorflow_profiler.py
+++ b/perfzero/lib/perfzero/tensorflow_profiler.py
@@ -1,0 +1,125 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Collect profiler data for Tensorboard with a separate thread."""
+
+from __future__ import print_function
+
+import logging
+import os
+import sched
+import threading
+import time
+import traceback
+
+import perfzero.utils as utils
+
+
+def _start_profiler():
+  from tensorflow.python.eager import profiler  # pylint: disable=g-import-not-at-top
+
+  try:
+    profiler.start()
+    logging.info('Started Tensorflow profiler')
+  except Exception:  # pylint: disable=W0703
+    logging.error('Tensorflow profiler failed to start due to error:\n %s',
+                  traceback.format_exc())
+
+
+def _stop_and_save_profiler(output_dir):
+  """Stop profiler and save profiler data.
+
+  Args:
+    output_dir: log directory to place the profiler data
+  """
+
+  from tensorflow.python.eager import profiler  # pylint: disable=g-import-not-at-top
+
+  try:
+    profiler_data_dir = os.path.join(output_dir, 'profiler_data')
+    logging.info('Stopping Tensorflow profiler and saving data to dir %s', profiler_data_dir)  # pylint: disable=line-too-long
+    utils.make_dir_if_not_exist(profiler_data_dir)
+    result = profiler.stop()
+    with open(os.path.join(profiler_data_dir, 'local.trace'), 'wb') as f:
+      f.write(result)
+    logging.info('Stopped Tensorflow profiler.')
+  except Exception:  # pylint: disable=W0703
+    logging.error('Tensorflow profiler failed to stop due to error:\n %s',
+                  traceback.format_exc())
+
+
+class TensorflowProfiler(object):
+  """Collect profiler data for Tensorboard with a separate thread."""
+
+  def __init__(self, profiler_enabled_time_str, output_dir):
+    """Constructor.
+
+    Args:
+      profiler_enabled_time_str: the value of the config --profiler_enabled_time
+      output_dir: log directory to place the profiler data
+    """
+
+    self.profiler_enabled_time_str = profiler_enabled_time_str
+    self.output_dir = output_dir
+    self.exit_event = threading.Event()
+    self.scheduler = sched.scheduler(time.time, self._sleep_until_exit)
+
+  def _sleep_until_exit(self, timeout):
+    start_time = time.time()
+    cur_time = time.time()
+    while cur_time - start_time < timeout and not self.exit_event.is_set():
+      time.sleep(min(1, timeout + start_time - cur_time))
+      cur_time = time.time()
+
+  def start(self):
+    """Schedule start/stop profiler event specified in profiler_enabled_time_str."""
+
+    if not self.profiler_enabled_time_str:
+      return
+
+    last_end_time = -1
+    for time_str in self.profiler_enabled_time_str.split(','):
+      begin_time = int(time_str.split(':')[0].strip())
+      end_time_str = time_str.split(':')[1].strip() if ':' in time_str else None
+      end_time = int(end_time_str) if end_time_str else 365 * 24 * 60 * 60
+      if begin_time <= last_end_time:
+        raise ValueError('begin_time {} is no larger than the last end_time {}'.format(begin_time, last_end_time))  # pylint: disable=line-too-long
+      if end_time <= begin_time:
+        raise ValueError('end_time {} is no larger than begin_time {}'.format(end_time, begin_time))  # pylint: disable=line-too-long
+      self.scheduler.enter(begin_time, 1, _start_profiler)  # pylint: disable=no-value-for-parameter
+      self.scheduler.enter(end_time, 1, _stop_and_save_profiler, argument=(self.output_dir,))  # pylint: disable=line-too-long
+      last_end_time = end_time
+
+    threading.Thread(target=self.scheduler.run).start()
+
+  def stop(self):
+    """Stop scheduler and save profiler data if any event is cancelled."""
+
+    event_canceled = False
+    for event in self.scheduler.queue:
+      try:
+        self.scheduler.cancel(event)
+        event_canceled = True
+      except ValueError:
+        # This is OK because the event may have been just canceled
+        pass
+
+    # Signal the scheduler thread to stop sleeping
+    self.exit_event.set()
+
+    # Save the profiler data if any event is canceled
+    if event_canceled:
+      _stop_and_save_profiler(self.output_dir)
+

--- a/perfzero/lib/perfzero/utils_test.py
+++ b/perfzero/lib/perfzero/utils_test.py
@@ -64,12 +64,3 @@ class TestUtils(unittest.TestCase):
     cpu_socket_count = utils.get_cpu_socket_count()
     self.assertEqual(2, cpu_socket_count)
 
-  @patch('perfzero.utils.get_cpu_socket_count')
-  @patch('perfzero.utils.run_command')
-  def test_get_cpu_core_count(self, run_command_mock,
-                              get_cpu_socket_count_mock):
-    """Tests get number of cores."""
-    run_command_mock.return_value = [0, 'cpu cores  : 6\n']
-    get_cpu_socket_count_mock.return_value = 2
-    cpu_core_count = utils.get_cpu_core_count()
-    self.assertEqual(12, cpu_core_count)

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     cmd = 'docker build --no-cache --pull -t {} --build-arg tensorflow_pip_spec={} - < {}'.format(  # pylint: disable=line-too-long
         docker_tag, FLAGS.tensorflow_pip_spec, dockerfile_path)
   else:
-    cmd = 'docker build --no-cache --pull -t {} - < {}'.format(docker_tag, dockerfile_path)
+    cmd = 'docker build --no-cache --pull -t {} - < {}'.format(docker_tag, dockerfile_path)  # pylint: disable=line-too-long
 
   utils.run_commands([cmd])
   logging.info('Built docker image with tag %s', docker_tag)

--- a/perfzero/scripts/plot_process_info.py
+++ b/perfzero/scripts/plot_process_info.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+#
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Plot graph showing process metric values over time"""
+
+from __future__ import print_function
+
+import argparse
+import sys
+import json
+import matplotlib.pyplot as plt
+import matplotlib.backends.backend_pdf as backend_pdf
+import matplotlib.ticker as tick
+
+colors=['b', 'r', 'g', 'c', 'pink']
+
+def visualize(file_path):
+
+  entries = []
+  with open(file_path) as f:
+    entries = [json.loads(line) for line in f.readlines() if line.strip()]
+
+  if not entries:
+    print('There is no data in file {}'.format(file_path))
+    return
+
+  pdf = backend_pdf.PdfPages("process_info.pdf")
+  idx = 0
+  names = [name for name in entries[0].keys() if name != 'time']
+  times = [entry['time'] for entry in entries]
+
+  for name in names:
+    values = [entry[name] for entry in entries]
+    fig = plt.figure()
+    ax = plt.gca()
+    ax.yaxis.set_major_formatter(tick.ScalarFormatter(useMathText=True))
+    plt.ticklabel_format(style='sci', axis='y', scilimits=(-2,3))
+    plt.plot(times, values, colors[idx % len(colors)], marker='x', label=name)
+    plt.xlabel('Time (sec)')
+    plt.ylabel(name)
+    plt.ylim(ymin=0)
+    plt.legend(loc = 'upper left')
+    pdf.savefig(fig)
+    idx += 1
+
+  plt.show()
+  pdf.close()
+  print('Generated process_info.pdf from {}'.format(file_path))
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(usage='plot_process_info.py <path_to_file>' )
+  parser.add_argument('file_path', type=str)
+  flags = parser.parse_args(sys.argv[1:])
+
+
+  visualize(flags.file_path)
+
+
+


### PR DESCRIPTION
This patch makes the following improvements:
    
- Added `max_rss`, `max_vms`, `max_cpu_percentage` as part of process_info in the benchmark summary. `rss` refers to physical memory size in bytes and `vms` refers to virtual memory size in bytes.
- Added `logical_cpu_count` as part of system_info in the benchmark summary
- Renamed `cpu_core_count` to `physical_cpu_count` in the benchmark summary
- The process info metrics over time will be logged in the file ${workspace}/output/${execution_id}/process_info.log
- Added `scripts/plot_process_info.py` to visualize process metrics over time. See README.md for instructions
