### PR TITLE
Add process_info to the big table schema

### DIFF
--- a/perfzero/scripts/create_big_table.txt
+++ b/perfzero/scripts/create_big_table.txt
@@ -34,5 +34,10 @@
     "name": "system_info",
     "type": "STRING",
     "mode": "NULLABLE"
+  },
+  {
+    "name": "process_info",
+    "type": "STRING",
+    "mode": "NULLABLE"
   }
 ]


### PR DESCRIPTION
The `process_info` field will encode the metrics related to the benchmark process, whereas the existing `system_info` field encodes the metrics related to the entire system. For example, we already have `max_rss` in `process_info` that shows the maximum physical memory used by the benchmark method. And in the future we can potentially have `min_free_memory` in `system_info` that shows the minimum free memory available on the system that executes the benchmark method.