### PR TITLE
Run benchmark method in a separate process

### DIFF
--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -114,9 +114,7 @@ class BenchmarkRunner(object):
       process.start()
       process.join()
       method_has_exception, method_execution_time, succeeded, output_dir = queue.get()  # pylint: disable=line-too-long
-
-      if method_has_exception:
-        has_exception = True
+      has_exception |= method_has_exception
       self.benchmark_execution_time[benchmark_method] = method_execution_time
       benchmark_success_results[benchmark_method] = succeeded
       benchmark_output_dirs[benchmark_method] = output_dir

--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -16,20 +16,16 @@
 from __future__ import print_function
 
 import argparse
-import datetime
-import importlib
 import json
 import logging
+import multiprocessing
 import os
 import re
 import sys
 import time
-import traceback
 
+import perfzero.benchmark_method_runner as benchmark_method_runner
 import perfzero.perfzero_config as perfzero_config
-from perfzero.process_info_tracker import ProcessInfoTracker
-import perfzero.report_utils as report_utils
-from perfzero.tensorflow_profiler import TensorFlowProfiler
 import perfzero.utils as utils
 
 
@@ -89,7 +85,7 @@ class BenchmarkRunner(object):
         index = benchmark_method_pattern.find(filter_prefix)
         benchmark_class = benchmark_method_pattern[:index - 1]
         pattern = benchmark_method_pattern[index + len(filter_prefix):]
-        class_instance = self._instantiate_benchmark_class(benchmark_class,
+        class_instance = utils.instantiate_benchmark_class(benchmark_class,
                                                            '/dev/null',
                                                            '')
         for benchmark_method_name in dir(class_instance):
@@ -106,108 +102,24 @@ class BenchmarkRunner(object):
     benchmark_output_dirs = {}
 
     for benchmark_method in self._get_benchmark_methods():
-      start_timestamp = time.time()
-      execution_timestamp = start_timestamp
-      method_has_exception = False
-      execution_id = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
-      output_dir = os.path.join(self.root_output_dir, execution_id)
-      utils.make_dir_if_not_exist(output_dir)
-      benchmark_output_dirs[benchmark_method] = output_dir
-      benchmark_class, benchmark_method_name = benchmark_method.rsplit('.', 1)
-      benchmark_class_name = benchmark_class.rsplit('.', 1)[1]
+      # Run the benchmark method in a separate process so that its memory usage
+      # will not affect the execution of other benchmark method
+      # This is a walkaround before we fix all memory leak issues in TensorFlow
+      queue = multiprocessing.Queue()
+      process = multiprocessing.Process(target=benchmark_method_runner.run,
+                                        args=(benchmark_method,
+                                              site_package_info,
+                                              self.root_output_dir,
+                                              self.config, queue))
+      process.start()
+      process.join()
+      method_has_exception, method_execution_time, succeeded, output_dir = queue.get()  # pylint: disable=line-too-long
 
-      tensorflow_profiler = TensorFlowProfiler(
-          self.config.profiler_enabled_time_str, output_dir)
-      process_info_tracker = ProcessInfoTracker(output_dir)
-      process_info = None
-
-      # Setup per-method file logger
-      filehandler = logging.FileHandler(
-          filename=os.path.join(output_dir, 'perfzero.log'), mode='w')
-      filehandler.setFormatter(
-          logging.Formatter('%(asctime)s %(levelname)s: %(message)s'))
-      logging.getLogger().addHandler(filehandler)
-
-      try:
-        class_instance = self._instantiate_benchmark_class(
-            benchmark_class, output_dir, self.config.root_data_dir)
-        # tf.test.Benchmark.report_benchmark() writes results to a file with
-        # path benchmark_result_file_path_prefix + benchmark_method
-        benchmark_result_file_path_prefix = os.path.join(output_dir, 'proto_')
-        os.environ['TEST_REPORT_FILE_PREFIX'] = benchmark_result_file_path_prefix  # pylint: disable=line-too-long
-        benchmark_result_file_path = '{}{}.{}'.format(
-            benchmark_result_file_path_prefix,
-            benchmark_class_name,
-            benchmark_method_name)
-
-        # Start background threads for profiler and system info tracker
-        tensorflow_profiler.start()
-        process_info_tracker.start()
-
-        # Run benchmark method
-        execution_timestamp = time.time()
-        logging.info('Starting benchmark execution: %s', benchmark_method)
-        getattr(class_instance, benchmark_method_name)()
-        logging.info('Stopped benchmark: %s', benchmark_method)
-
-        # Read and build benchmark results
-        raw_benchmark_result = utils.read_benchmark_result(
-            benchmark_result_file_path)
-        # Explicitly overwrite the name to be the full path to benchmark method
-        raw_benchmark_result['name'] = benchmark_method
-      except Exception:  # pylint: disable=broad-except
-        logging.error('Benchmark execution for %s failed due to error:\n %s',
-                      benchmark_method, traceback.format_exc())
-        method_has_exception = True
+      if method_has_exception:
         has_exception = True
-        raw_benchmark_result = {}
-        raw_benchmark_result['name'] = benchmark_method
-        raw_benchmark_result['wall_time'] = -1
-        raw_benchmark_result['extras'] = {}
-      finally:
-        # Stop background threads for profiler and system info tracker
-        process_info = process_info_tracker.stop()
-        tensorflow_profiler.stop()
-
-      upload_timestamp = time.time()
-      benchmark_result = report_utils.build_benchmark_result(
-          raw_benchmark_result, method_has_exception)
-      benchmark_success_results[benchmark_method] = benchmark_result['succeeded']  # pylint: disable=line-too-long
-      execution_summary = report_utils.build_execution_summary(
-          execution_timestamp,
-          execution_id,
-          self.config.ml_framework_build_label,
-          self.config.execution_label,
-          self.config.platform_name,
-          self.config.system_name,
-          self.config.output_gcs_url,
-          benchmark_result,
-          self.config.get_env_vars(),
-          self.config.get_flags(),
-          site_package_info,
-          process_info,
-          method_has_exception)
-      report_utils.upload_execution_summary(
-          self.config.bigquery_project_name,
-          self.config.bigquery_dataset_table_name,
-          execution_summary)
-      logging.info('Benchmark execution for %s completed with summary:\n %s',
-                   benchmark_method, json.dumps(execution_summary, indent=2))
-      utils.maybe_upload_to_gcs(output_dir, self.config.output_gcs_url)
-      logging.getLogger().removeHandler(filehandler)
-      self.benchmark_execution_time[benchmark_method] = {
-          'class_initialization': execution_timestamp - start_timestamp,
-          'method_execution': upload_timestamp - execution_timestamp,
-          'log_upload': time.time() - upload_timestamp
-      }
-
-      if self.config.profiler_enabled_time_str:
-        relative_output_dir = output_dir[output_dir.find('benchmark'):]
-        print('\nExecute the command below to start tensorboard server using '
-              'the collected profiler data:\ntensorboard --logdir={}\n\n'
-              'Open localhost:6006 in your browser to access the Tensorbord '
-              'GUI. Use ssh with port forwarding if tensorboard is running on '
-              'a remote machine.\n'.format(relative_output_dir))
+      self.benchmark_execution_time[benchmark_method] = method_execution_time
+      benchmark_success_results[benchmark_method] = succeeded
+      benchmark_output_dirs[benchmark_method] = output_dir
 
     print('Benchmark execution time in seconds by operation:\n {}'.format(
         json.dumps(self.benchmark_execution_time, indent=2)))
@@ -217,16 +129,6 @@ class BenchmarkRunner(object):
         json.dumps(benchmark_output_dirs, indent=2)))
     if has_exception:
       sys.exit(1)
-
-  def _instantiate_benchmark_class(self, benchmark_class,
-                                   output_dir, root_data_dir):
-    """Return initialized benchmark class."""
-    module_import_path, class_name = benchmark_class.rsplit('.', 1)
-    module = importlib.import_module(module_import_path)
-    class_ = getattr(module, class_name)
-    instance = class_(output_dir=output_dir, root_data_dir=root_data_dir)
-
-    return instance
 
 
 if __name__ == '__main__':

--- a/perfzero/lib/perfzero/benchmark_method_runner.py
+++ b/perfzero/lib/perfzero/benchmark_method_runner.py
@@ -1,0 +1,155 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Execute a single benchmark method."""
+from __future__ import print_function
+
+import datetime
+import json
+import logging
+import os
+import time
+import traceback
+
+from perfzero.process_info_tracker import ProcessInfoTracker
+import perfzero.report_utils as report_utils
+from perfzero.tensorflow_profiler import TensorFlowProfiler
+import perfzero.utils as utils
+
+
+def run(benchmark_method, site_package_info, root_output_dir, config, queue):
+  try:
+    _run_internal(benchmark_method, site_package_info,
+                  root_output_dir, config, queue)
+  except Exception:  # pylint: disable=broad-except
+    logging.error('Benchmark execution for %s failed due to error:\n %s',
+                  benchmark_method, traceback.format_exc())
+    queue.put((True, None, False, None))
+
+
+def _run_internal(benchmark_method, site_package_info,
+                  root_output_dir, config, queue):
+  """Run benchmark method and put result to the queue.
+
+  Args:
+    benchmark_method: Canonical path to the benchmark method
+    site_package_info:
+    root_output_dir: Directory under which to put the benchmark output
+    config: An instance of perfzero_config
+    queue: An interprocess queue to transfer benchmark result to the caller
+  """
+  start_timestamp = time.time()
+  execution_timestamp = start_timestamp
+  method_has_exception = False
+  execution_id = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+  output_dir = os.path.join(root_output_dir, execution_id)
+  utils.make_dir_if_not_exist(output_dir)
+  benchmark_class, benchmark_method_name = benchmark_method.rsplit('.', 1)
+  benchmark_class_name = benchmark_class.rsplit('.', 1)[1]
+
+  tensorflow_profiler = TensorFlowProfiler(
+      config.profiler_enabled_time_str, output_dir)
+  process_info_tracker = ProcessInfoTracker(output_dir)
+  process_info = None
+
+  # Setup per-method file logger
+  filehandler = logging.FileHandler(
+      filename=os.path.join(output_dir, 'perfzero.log'), mode='w')
+  filehandler.setFormatter(
+      logging.Formatter('%(asctime)s %(levelname)s: %(message)s'))
+  logging.getLogger().addHandler(filehandler)
+
+  try:
+    class_instance = utils.instantiate_benchmark_class(
+        benchmark_class, output_dir, config.root_data_dir)
+    # tf.test.Benchmark.report_benchmark() writes results to a file with
+    # path benchmark_result_file_path_prefix + benchmark_method
+    benchmark_result_file_path_prefix = os.path.join(output_dir, 'proto_')
+    os.environ['TEST_REPORT_FILE_PREFIX'] = benchmark_result_file_path_prefix
+    benchmark_result_file_path = '{}{}.{}'.format(
+        benchmark_result_file_path_prefix,
+        benchmark_class_name,
+        benchmark_method_name)
+
+    # Start background threads for profiler and system info tracker
+    tensorflow_profiler.start()
+    process_info_tracker.start()
+
+    # Run benchmark method
+    execution_timestamp = time.time()
+    logging.info('Starting benchmark execution: %s', benchmark_method)
+    getattr(class_instance, benchmark_method_name)()
+    logging.info('Stopped benchmark: %s', benchmark_method)
+
+    # Read and build benchmark results
+    raw_benchmark_result = utils.read_benchmark_result(
+        benchmark_result_file_path)
+    # Explicitly overwrite the name to be the full path to benchmark method
+    raw_benchmark_result['name'] = benchmark_method
+  except Exception:  # pylint: disable=broad-except
+    logging.error('Benchmark execution for %s failed due to error:\n %s',
+                  benchmark_method, traceback.format_exc())
+    method_has_exception = True
+    raw_benchmark_result = {}
+    raw_benchmark_result['name'] = benchmark_method
+    raw_benchmark_result['wall_time'] = -1
+    raw_benchmark_result['extras'] = {}
+  finally:
+    # Stop background threads for profiler and system info tracker
+    process_info = process_info_tracker.stop()
+    tensorflow_profiler.stop()
+
+  upload_timestamp = time.time()
+  benchmark_result = report_utils.build_benchmark_result(
+      raw_benchmark_result, method_has_exception)
+  execution_summary = report_utils.build_execution_summary(
+      execution_timestamp,
+      execution_id,
+      config.ml_framework_build_label,
+      config.execution_label,
+      config.platform_name,
+      config.system_name,
+      config.output_gcs_url,
+      benchmark_result,
+      config.get_env_vars(),
+      config.get_flags(),
+      site_package_info,
+      process_info,
+      method_has_exception)
+  report_utils.upload_execution_summary(
+      config.bigquery_project_name,
+      config.bigquery_dataset_table_name,
+      execution_summary)
+  logging.info('Benchmark execution for %s completed with summary:\n %s',
+               benchmark_method, json.dumps(execution_summary, indent=2))
+  utils.maybe_upload_to_gcs(output_dir, config.output_gcs_url)
+  logging.getLogger().removeHandler(filehandler)
+  method_execution_time = {
+      'class_initialization': execution_timestamp - start_timestamp,
+      'method_execution': upload_timestamp - execution_timestamp,
+      'log_upload': time.time() - upload_timestamp
+  }
+
+  if config.profiler_enabled_time_str:
+    relative_output_dir = output_dir[output_dir.find('benchmark'):]
+    print('\nExecute the command below to start tensorboard server using '
+          'the collected profiler data:\ntensorboard --logdir={}\n\n'
+          'Open localhost:6006 in your browser to access the Tensorbord '
+          'GUI. Use ssh with port forwarding if tensorboard is running on '
+          'a remote machine.\n'.format(relative_output_dir))
+
+  queue.put((method_has_exception, method_execution_time,
+             benchmark_result['succeeded'], output_dir))
+
+

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -15,6 +15,7 @@
 """PerfZero utility methods."""
 from __future__ import print_function
 
+import importlib
 import logging
 import os
 import subprocess
@@ -337,3 +338,14 @@ def print_thread_stacktrace():
   for thread_id, frame in sys._current_frames().items():  # pylint: disable=protected-access
     print('Thread {}'.format(thread_names.get(thread_id, thread_id)))
     traceback.print_stack(frame)
+
+
+def instantiate_benchmark_class(benchmark_class, output_dir, root_data_dir):
+  """Return initialized benchmark class."""
+  module_import_path, class_name = benchmark_class.rsplit('.', 1)
+  module = importlib.import_module(module_import_path)
+  class_ = getattr(module, class_name)
+  instance = class_(output_dir=output_dir, root_data_dir=root_data_dir)
+
+  return instance
+


### PR DESCRIPTION
Currently PerfZero runs all benchmark methods in one process. This causes two problems:

1) The memory used by one benchmark method may not be properly release by TensorFlow due to e.g. memory leak. This will negatively impact the performance of benchmark methods that are run later.

2) Some configuration used in TensorFlow, such as eager mode or not, is global. A benchmark method may mistakenly used the non-default configuration that set by the previous benchmark method, causing deterministic behavior.

This patch changes PerfZero to run each benchmark method in a separate process to prevent them from affecting each other.