### PR TITLE
Print benchmark method names before executing these methods

### DIFF
--- a/perfzero/README.md
+++ b/perfzero/README.md
@@ -150,6 +150,11 @@ key when the name of the key is not sufficiently self-explanary.
       }
     },
     "harness_name": "perfzero",
+    "harness_info": {
+      "url": "https://github.com/tensorflow/benchmarks.git",
+      "branch": "master",
+      "hash": "75d2991b88630dde10ef65aad8082a6d5cd8b5fc"
+    },
     "execution_label": "execution_label"      # Specified by the flag --execution_label
   },
 

--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -34,8 +34,9 @@ class BenchmarkRunner(object):
 
   def __init__(self, config):
     self.config = config
-    project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-    self.workspace_dir = os.path.join(project_dir, config.workspace)
+    self.project_dir = os.path.abspath(
+        os.path.dirname(os.path.dirname(__file__)))
+    self.workspace_dir = os.path.join(self.project_dir, config.workspace)
     self.site_packages_dir = os.path.join(self.workspace_dir, 'site-packages')
     self.root_output_dir = os.path.join(self.workspace_dir, 'output')
     self.benchmark_execution_time = {}
@@ -92,10 +93,14 @@ class BenchmarkRunner(object):
           if re.match(pattern, benchmark_method_name):
             benchmark_methods.append(benchmark_class + '.' +
                                      benchmark_method_name)
+
+    logging.info('The following benchmark methods will be executed: %s',
+                 benchmark_methods)
     return benchmark_methods
 
   def run_benchmark(self):
     """Run benchmark."""
+    harness_info = utils.get_git_repo_info(self.project_dir)
     site_package_info = self._setup()
     has_exception = False
     benchmark_success_results = {}
@@ -108,6 +113,7 @@ class BenchmarkRunner(object):
       queue = multiprocessing.Queue()
       process = multiprocessing.Process(target=benchmark_method_runner.run,
                                         args=(benchmark_method,
+                                              harness_info,
                                               site_package_info,
                                               self.root_output_dir,
                                               self.config, queue))

--- a/perfzero/lib/perfzero/benchmark_method_runner.py
+++ b/perfzero/lib/perfzero/benchmark_method_runner.py
@@ -28,9 +28,10 @@ from perfzero.tensorflow_profiler import TensorFlowProfiler
 import perfzero.utils as utils
 
 
-def run(benchmark_method, site_package_info, root_output_dir, config, queue):
+def run(benchmark_method, harness_info, site_package_info,
+        root_output_dir, config, queue):
   try:
-    _run_internal(benchmark_method, site_package_info,
+    _run_internal(benchmark_method, harness_info, site_package_info,
                   root_output_dir, config, queue)
   except Exception:  # pylint: disable=broad-except
     logging.error('Benchmark execution for %s failed due to error:\n %s',
@@ -38,13 +39,14 @@ def run(benchmark_method, site_package_info, root_output_dir, config, queue):
     queue.put((True, None, False, None))
 
 
-def _run_internal(benchmark_method, site_package_info,
+def _run_internal(benchmark_method, harness_info, site_package_info,
                   root_output_dir, config, queue):
   """Run benchmark method and put result to the queue.
 
   Args:
     benchmark_method: Canonical path to the benchmark method
-    site_package_info:
+    harness_info: Description of the benchmark harness used in the benchmark
+    site_package_info: Description of the site-package used in the benchmark
     root_output_dir: Directory under which to put the benchmark output
     config: An instance of perfzero_config
     queue: An interprocess queue to transfer benchmark result to the caller
@@ -124,6 +126,7 @@ def _run_internal(benchmark_method, site_package_info,
       benchmark_result,
       config.get_env_vars(),
       config.get_flags(),
+      harness_info,
       site_package_info,
       process_info,
       method_has_exception)

--- a/perfzero/lib/perfzero/report_utils.py
+++ b/perfzero/lib/perfzero/report_utils.py
@@ -134,7 +134,7 @@ def build_benchmark_result(raw_benchmark_result, has_exception):
 def build_execution_summary(execution_timestamp, execution_id,
                             ml_framework_build_label, execution_label,
                             platform_name, system_name, output_gcs_url,
-                            benchmark_result, env_vars, flags,
+                            benchmark_result, env_vars, flags, harness_info,
                             site_package_info, process_info, has_exception):
   """Builds summary of the execution."""
   # Avoids module not found during setup phase when tf is not installed yet.
@@ -143,6 +143,7 @@ def build_execution_summary(execution_timestamp, execution_id,
 
   benchmark_info = {}
   benchmark_info['harness_name'] = 'perfzero'
+  benchmark_info['harness_info'] = harness_info
   benchmark_info['has_exception'] = has_exception
   if execution_label:
     benchmark_info['execution_label'] = execution_label


### PR DESCRIPTION
This patch makes the following improvements:

- Print benchmark method names before executing these methods
- Include git information of the PerfZero in the benchmark summary