### PR TITLE
Do git pull for site-packages by default

### DIFF
--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -146,7 +146,7 @@ if __name__ == '__main__':
                       level=level)
 
   if unparsed:
-    logging.warning('Arguments %s are not recognized', unparsed)
+    logging.error('Arguments %s are not recognized', unparsed)
     sys.exit(1)
 
   config_ = perfzero_config.PerfZeroConfig(mode='flags', flags=FLAGS)

--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -65,7 +65,7 @@ class BenchmarkRunner(object):
     start_time = time.time()
     site_package_info = utils.checkout_git_repos(
         self.config.get_git_repos(self.site_packages_dir),
-        self.config.force_update)
+        self.config.use_cached_site_packages)
     self.benchmark_execution_time['checkout_repository'] = (
         time.time() - start_time)
 
@@ -147,6 +147,7 @@ if __name__ == '__main__':
 
   if unparsed:
     logging.warning('Arguments %s are not recognized', unparsed)
+    sys.exit(1)
 
   config_ = perfzero_config.PerfZeroConfig(mode='flags', flags=FLAGS)
   benchmark_runner = BenchmarkRunner(config_)

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -66,9 +66,9 @@ def add_setup_parser_arguments(parser):
 def add_benchmark_parser_arguments(parser):
   """Add arguments to the parser used by the benchmark.py."""
   parser.add_argument(
-      '--force_update',
+      '--use_cached_site_packages',
       action='store_true',
-      help='If set, do git pull for dependent git repositories'
+      help='If set, skip git pull for dependent git repositories if it already exists in path_to_perfzero/${workspace}/site-packages'
       )
   parser.add_argument(
       '--gcs_downloads',
@@ -214,7 +214,7 @@ class PerfZeroConfig(object):
       self.bigquery_dataset_table_name = flags.bigquery_dataset_table_name
       self.python_path_str = flags.python_path
       self.workspace = flags.workspace
-      self.force_update = flags.force_update
+      self.use_cached_site_packages = flags.use_cached_site_packages
       self.root_data_dir = flags.root_data_dir
       self.gcloud_key_file_url = flags.gcloud_key_file_url
       self.profiler_enabled_time_str = flags.profiler_enabled_time

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -25,12 +25,12 @@ import traceback
 import requests
 
 
-def checkout_git_repos(git_repos, force_update):
+def checkout_git_repos(git_repos, use_cached_site_packages):
   """Clone, update, or sync a repo.
 
   Args:
     git_repos: array of dict containing attributes of the git repo to checkout
-    force_update: Always do git pull if True
+    use_cached_site_packages: If true, skip git pull if the git_repo already exists
 
   Returns:
     A dict containing attributes of the git repositories
@@ -44,7 +44,7 @@ def checkout_git_repos(git_repos, force_update):
     if 'branch' in repo:
       run_commands(['git -C {} checkout {}'.format(
           repo['local_path'], repo['branch'])])
-    if force_update or 'git_hash' in repo:
+    if not use_cached_site_packages or 'git_hash' in repo:
       run_commands(['git -C {} pull'.format(repo['local_path'])])
     if 'git_hash' in repo:
       run_commands(['git -C {} reset --hard {}'.format(

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
   logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
                       level=logging.DEBUG)
   if unparsed:
-    logging.warning('Arguments %s are not recognized', unparsed)
+    logging.error('Arguments %s are not recognized', unparsed)
     sys.exit(1)
 
   setup_execution_time = {}

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -36,6 +36,7 @@ if __name__ == '__main__':
                       level=logging.DEBUG)
   if unparsed:
     logging.warning('Arguments %s are not recognized', unparsed)
+    sys.exit(1)
 
   setup_execution_time = {}
   project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
This patch makes the following improvements:
- Do git pull for site-packages by default
- Add argument --cached_site_packagesdd argument to optionally skip git pull for site-packages
- Exit with non-zero code if there is unrecognized argument
