### PR TITLE
Allow user to specify file:///path_to_file as gcloud_key_file_url

### DIFF
--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -37,9 +37,11 @@ def add_setup_parser_arguments(parser):
       ''')
   parser.add_argument(
       '--gcloud_key_file_url',
-      default='gs://tf-performance/auth_tokens/benchmark_upload_gce.json',
+      default='',
       type=str,
-      help='''The gcloud key file url. When specified, it will be downloaded to the directory specified by the flag --workspace.
+      help='''DEPRECATED: Use --gcloud_key_file_url of setup.py instead.
+      The gcloud key file url. When specified, it will be downloaded to the
+      directory specified by the flag --workspace. Each url can start with file://, gcs://, http:// or https://.
       ''')
   parser.add_argument(
       '--root_data_dir',
@@ -171,13 +173,16 @@ def add_benchmark_parser_arguments(parser):
       Data will be copied from ${url} to ${root_data_dir}/${relative_path}. ${relative_path} can be skipped if it is the same as the
       base name of the url, which shortens the format to url_1,url_2,... ${root_data_dir} is specified by the flag --root_data_dir.
       File will be de-compressed in ${root_data_dir} if its name ends with 'gz'. Only url prefixed with gcs, http or https are supported.
+      Each url can start with file://, gcs://, http:// or https://.
       ''')
   parser.add_argument(
       '--gcloud_key_file_url',
       default='gs://tf-performance/auth_tokens/benchmark_upload_gce.json',
       type=str,
-      help='The gcloud key file url. When specified, it will be activated and used as the gcloud authentication credential.'
-      )
+      help='''The gcloud key file url. When specified, it will be downloaded to the
+      directory specified by the flag --workspace. Each url can start with file://, gcs://, http:// or https://.
+      The key file will then be activated and used as gcloud authentication credential.
+      ''')
   parser.add_argument(
       '--debug',
       action='store_true',

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -163,6 +163,9 @@ def download_data(download_infos):
     elif info['url'].startswith('gs://'):
       cmd = ['gsutil', '-m', 'cp', '-r', '-n', info['url'], local_path_parent]
       run_commands([cmd], shell=False)
+    elif info['url'].startswith('file://'):
+      cmd = ['cp', info['url'][7:], local_path_parent]
+      run_commands([cmd], shell=False)
     else:
       raise ValueError('Url {} with prefix {} is not supported.'.format(
           info['url'], info['url'].split(':')[0]))


### PR DESCRIPTION
This patch makes the following improvements:
- Allow user to specify path to a local file for --gcloud_key_file_url and --data_downloads
- Change default value of --gcloud_key_file_url of setup.py to empty string so that setup.py do not download gcloud key file by default. Deprecate --gcloud_key_file_url of setup.py and user should only use --gcloud_key_file_url of benchmark.py
- Clarify the supported protocol for --gcloud_key_file_url and --data_downloads in the helper message