### PR TITLE
Use git pull --rebase when pulling latest site-packages

### DIFF
--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -45,7 +45,7 @@ def checkout_git_repos(git_repos, use_cached_site_packages):
       run_commands(['git -C {} checkout {}'.format(
           repo['local_path'], repo['branch'])])
     if not use_cached_site_packages or 'git_hash' in repo:
-      run_commands(['git -C {} pull'.format(repo['local_path'])])
+      run_commands(['git -C {} pull --rebase'.format(repo['local_path'])])
     if 'git_hash' in repo:
       run_commands(['git -C {} reset --hard {}'.format(
           repo['local_path'], repo['git_hash'])])


### PR DESCRIPTION
In comparison to "git pull", "git pull --rebase" has the advantage that 1) local commit always stays at the top of the local git history and 2) there is no need for an additional auto-generated commit with the message "Merge branch ..."