### PR TITLE
Include default value fields when converting protobuf message to dict

### DIFF
--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -332,7 +332,9 @@ def read_benchmark_result(benchmark_result_file_path):
     benchmark_entries.ParseFromString(f.read())
 
     return json_format.MessageToDict(
-        benchmark_entries, preserving_proto_field_name=True)['entry'][0]
+        benchmark_entries,
+        preserving_proto_field_name=True,
+        including_default_value_fields=True)['entry'][0]
 
 
 def print_thread_stacktrace():

--- a/perfzero/lib/perfzero/utils_test.py
+++ b/perfzero/lib/perfzero/utils_test.py
@@ -13,15 +13,63 @@
 # limitations under the License.
 # ==============================================================================
 """Tests utils.py."""
-import unittest
 
+import os
+import unittest
 from mock import call
 from mock import MagicMock
 from mock import patch
 import perfzero.utils as utils
+import tensorflow as tf  # pylint: disable=g-bad-import-order
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(unittest.TestCase, tf.test.Benchmark):
+
+  def test_protobuf_read(self):
+    output_dir = '/tmp/'
+    os.environ['TEST_REPORT_FILE_PREFIX'] = output_dir
+    benchmark_result_file_path = os.path.join(output_dir,
+                                              'TestUtils.testReportBenchmark')
+    if os.path.exists(benchmark_result_file_path):
+      os.remove(benchmark_result_file_path)
+
+    self.report_benchmark(
+        iters=2000,
+        wall_time=1000,
+        name='testReportBenchmark',
+        metrics=[{'name': 'metric_name_1', 'value': 0, 'min_value': 1},
+                 {'name': 'metric_name_2', 'value': 90, 'min_value': 0,
+                  'max_value': 95}])
+
+    actual_result = utils.read_benchmark_result(
+        benchmark_result_file_path)
+    os.remove(benchmark_result_file_path)
+
+    expected_result = {
+        'name': 'TestUtils.testReportBenchmark',
+        # google.protobuf.json_format.MessageToDict() will convert
+        # int64 field to string.
+        'iters': '2000',
+        'wall_time': 1000,
+        'cpu_time': 0,
+        'throughput': 0,
+        'extras': {},
+        'metrics': [
+            {
+                'name': 'metric_name_1',
+                'value': 0,
+                'min_value': 1
+            },
+            {
+                'name': 'metric_name_2',
+                'value': 90,
+                'min_value': 0,
+                'max_value': 95
+            }
+        ]
+    }
+
+    self.assertDictEqual(expected_result, actual_result)
 
   @patch('perfzero.utils.get_git_repo_info')
   @patch('perfzero.utils.run_commands')
@@ -53,7 +101,7 @@ class TestUtils(unittest.TestCase):
     run_commands_mock.assert_has_calls(any_order=False, calls=[
         call(['git clone url_1 local_path_1']),
         call(['git -C local_path_1 checkout branch_1']),
-        call(['git -C local_path_1 pull']),
+        call(['git -C local_path_1 pull --rebase']),
         call(['git -C local_path_1 reset --hard git_hash_1']),
         call(['git clone url_2 local_path_2']),
         call(['git -C local_path_2 checkout branch_2'])


### PR DESCRIPTION
By default `google.protobuf.json_format.MessageToDict(...)` will not include a field in the output if its value is the default value (e.g. 0 for double-typed field). This prevents reader from reading a value even if the writer explicitly specifies the value as 0 when calling e.g. `tf.test.Benchmark.report_benchmark(...)`. We can fix this behavior by specifying `including_default_value_fields=True` when calling `MessageToDict(...)`.