### PR TITLE
Link should not point to a forked repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository contains various TensorFlow benchmarks. Currently, it consists of two projects:
 
 
-1. [PerfZero](https://github.com/lindong28/benchmarks/tree/master/perfzero): A benchmark framework for TensorFlow.
+1. [PerfZero](https://github.com/tensorflow/benchmarks/tree/master/perfzero): A benchmark framework for TensorFlow.
 
 2. [scripts/tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks): The TensorFlow CNN benchmarks contain benchmarks for several convolutional neural networks.
 


### PR DESCRIPTION
Currently, the `perfzero` link is pointing to a forked repository. This could be really confusing and needs to be corrected. The link should point to the folder `perfzero` inside the repository itself.