### PR TITLE
Ensure we do not miss output when running commands in subprocess

### DIFF
--- a/perfzero/lib/cloud_manager.py
+++ b/perfzero/lib/cloud_manager.py
@@ -43,27 +43,18 @@ def run_command(cmd, is_from_user=False):
   Raises:
     Exception: raised when the command execution has non-zero exit code
   """
-  if is_from_user:
-    logging.info('Executing command: %s\n', cmd)
-  else:
-    logging.debug('Executing command: %s\n', cmd)
+  def _log(text):
+    if is_from_user:
+      logging.info(text)
+    else:
+      logging.debug(text)
 
-  stdout = ''
+  _log('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=True)
-  exit_code = None
-  while exit_code is None:
-    exit_code = p.poll()
-    line = p.stdout.readline().decode('utf-8').strip()
-    if not line:
-      continue
-
-    if is_from_user:
-      logging.info(line)
-    else:
-      logging.debug(line)
-    stdout = stdout + line + '\n'
-
+  exit_code = p.wait()
+  stdout = p.stdout.decode('utf-8')
+  _log(stdout)
   if exit_code and is_from_user:
     sys.exit(exit_code)
   elif exit_code:

--- a/perfzero/lib/cloud_manager.py
+++ b/perfzero/lib/cloud_manager.py
@@ -47,10 +47,15 @@ def run_command(cmd, is_from_user=False):
   _log('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=True)
-  stdout, _ = p.communicate()
-  stdout = stdout.decode('utf-8')
-  exit_code = p.returncode
-  _log(stdout)
+
+  exit_code = None
+  line = ''
+  stdout = ''
+  while exit_code is None or line:
+    exit_code = p.poll()
+    line = p.stdout.readline().decode('utf-8')
+    stdout += line
+    _log(line)
   if exit_code and is_from_user:
     sys.exit(exit_code)
   elif exit_code:

--- a/perfzero/lib/cloud_manager.py
+++ b/perfzero/lib/cloud_manager.py
@@ -52,8 +52,8 @@ def run_command(cmd, is_from_user=False):
   _log('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=True)
-  exit_code = p.wait()
-  stdout = p.stdout.decode('utf-8')
+  stdout, _ = p.communicate().decode('utf-8')
+  exit_code = p.returncode
   _log(stdout)
   if exit_code and is_from_user:
     sys.exit(exit_code)

--- a/perfzero/lib/cloud_manager.py
+++ b/perfzero/lib/cloud_manager.py
@@ -43,12 +43,7 @@ def run_command(cmd, is_from_user=False):
   Raises:
     Exception: raised when the command execution has non-zero exit code
   """
-  def _log(text):
-    if is_from_user:
-      logging.info(text)
-    else:
-      logging.debug(text)
-
+  _log = logging.info if is_from_user else logging.debug
   _log('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=True)

--- a/perfzero/lib/cloud_manager.py
+++ b/perfzero/lib/cloud_manager.py
@@ -52,7 +52,8 @@ def run_command(cmd, is_from_user=False):
   _log('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=True)
-  stdout, _ = p.communicate().decode('utf-8')
+  stdout, _ = p.communicate()
+  stdout = stdout.decode('utf-8')
   exit_code = p.returncode
   _log(stdout)
   if exit_code and is_from_user:

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -245,9 +245,9 @@ def run_command(cmd, shell=True):
   logging.debug('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=shell)
-  stdout, _ = p.communicate().decode('utf-8')
+  stdout, _ = p.communicate()
   exit_code = p.returncode
-  return exit_code, stdout
+  return exit_code, stdout.decode('utf-8')
 
 
 def run_commands(cmds, shell=True):

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -245,8 +245,8 @@ def run_command(cmd, shell=True):
   logging.debug('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=shell)
-  exit_code = p.wait()
-  stdout = p.stdout.decode('utf-8')
+  stdout, _ = p.communicate().decode('utf-8')
+  exit_code = p.returncode
   return exit_code, stdout
 
 

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -245,9 +245,17 @@ def run_command(cmd, shell=True):
   logging.debug('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=shell)
-  stdout, _ = p.communicate()
-  exit_code = p.returncode
-  return exit_code, stdout.decode('utf-8')
+
+  exit_code = None
+  line = ''
+  stdout = ''
+  while exit_code is None or line:
+    exit_code = p.poll()
+    line = p.stdout.readline().decode('utf-8')
+    stdout += line
+    logging.debug(line)
+
+  return exit_code, stdout
 
 
 def run_commands(cmds, shell=True):

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -242,16 +242,11 @@ def run_command(cmd, shell=True):
   Returns:
     Tuple of the command return value and the standard out in as a string.
   """
-  logging.debug('Executing command: %s', cmd)
+  logging.debug('Executing command: {}'.format(cmd))
   p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, shell=shell)
-  stdout = ''
-  exit_code = None
-  while exit_code is None:
-    exit_code = p.poll()
-    line_str = p.stdout.readline().decode('utf-8')
-    logging.debug(line_str)
-    stdout += line_str
+  exit_code = p.wait()
+  stdout = p.stdout.decode('utf-8')
   return exit_code, stdout
 
 


### PR DESCRIPTION
In the previous implementation, sometimes we would not get all the stdout from the subprocess.  This changes the implementation to first wait for the process to exit, and then get return all the stdout.

`subprocess.run` makes this easy but it is only available in Python 3.