### PR TITLE
Run `pip3 install wheel` before installing other packages.

### DIFF
--- a/perfzero/docker/Dockerfile
+++ b/perfzero/docker/Dockerfile
@@ -36,8 +36,9 @@ RUN apt-get install -y --no-install-recommends \
 # Setup Python3 environment
 RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
+RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client google-cloud google-cloud-bigquery
-RUN pip3 install wheel absl-py
+RUN pip3 install absl-py
 RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt

--- a/perfzero/docker/Dockerfile_ubuntu_1804_build
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_build
@@ -68,8 +68,9 @@ RUN apt-get install -y --no-install-recommends \
 # Setup Python3 environment
 RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
+RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery
-RUN pip3 install wheel absl-py
+RUN pip3 install absl-py
 RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 RUN pip3 install tfds-nightly
 RUN pip3 install -U scikit-learn

--- a/perfzero/docker/Dockerfile_ubuntu_1804_cudnn7_6_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_cudnn7_6_tf_v2
@@ -64,8 +64,9 @@ RUN apt-get install -y --no-install-recommends \
 # Setup Python3 environment
 RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
+RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery
-RUN pip3 install wheel absl-py
+RUN pip3 install absl-py
 RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 RUN pip3 install tfds-nightly
 RUN pip3 install -U scikit-learn

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_custom_pip
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_custom_pip
@@ -71,8 +71,9 @@ RUN apt-get install -y --no-install-recommends \
 # Setup Python3 environment
 RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
+RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery
-RUN pip3 install wheel absl-py
+RUN pip3 install absl-py
 RUN pip3 install --upgrade --force-reinstall /tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl
 RUN pip3 install tfds-nightly
 RUN pip3 install -U scikit-learn

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
@@ -62,8 +62,9 @@ RUN apt-get install -y --no-install-recommends \
 # Setup Python3 environment
 RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
+RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
-RUN pip3 install wheel absl-py
+RUN pip3 install absl-py
 RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 RUN pip3 install -U scikit-learn
 

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -62,8 +62,9 @@ RUN apt-get install -y --no-install-recommends \
 # Setup Python3 environment
 RUN pip3 install --upgrade pip==9.0.1
 # setuptools upgraded to fix install requirements from model garden.
+RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
-RUN pip3 install wheel absl-py
+RUN pip3 install absl-py
 RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
 RUN pip3 install tfds-nightly
 RUN pip3 install -U scikit-learn


### PR DESCRIPTION
This fixes the following errors during Docker build:
```
error: invalid command 'bdist_wheel'
```