### PR TITLE
fix the issue of string_to_number as coco dataset input

### DIFF
--- a/scripts/tf_cnn_benchmarks/preprocessing.py
+++ b/scripts/tf_cnn_benchmarks/preprocessing.py
@@ -946,7 +946,9 @@ class COCOPreprocessor(BaseImagePreprocessor):
     image_buffer = data['image_buffer']
     boxes = data['groundtruth_boxes']
     classes = tf.reshape(data['groundtruth_classes'], [-1, 1])
-    source_id = tf.string_to_number(data['source_id'])
+    source_id0, source_id1 = tf.split(tf.strings.split(data['source_id'], sep='.', result_type="RaggedTensor"), [1, 1], 0)
+    source_id = tf.string_to_number(source_id0)
+    #source_id = tf.string_to_number(data['source_id'])
     raw_shape = data['raw_shape']
 
     ssd_encoder = ssd_dataloader.Encoder()


### PR DESCRIPTION
Fix the issue: https://github.com/tensorflow/benchmarks/issues/408
When the input data is coco dataset,
The input file name is something like 000000397133.jpg.
So when transform the file name to number, would get the error of:
```
tensorflow.python.framework.errors_impl.InvalidArgumentError: StringToNumberOp could not correctly convert string: 000000397133.jpg
         [[{{node StringToNumber}}]]
         [[batch_processing/IteratorGetNext]]
```
Fix this issue by split the name to [000000397133, jpg]
and keep the first one.
