### PR TITLE
Upgrade pip, move to cudnn 7.6, and new tensorrt

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
@@ -1,20 +1,29 @@
 # Ubuntu 18.04 Python3 with CUDA 10 and the following:
 #  - Installs tf-nightly-gpu
 #  - Installs requirements.txt for tensorflow/models
+#
+# This docker is not needed and is the same as the tf_v2 docker. The
+# User can pass in the desired `ARG tensorflow_pip_spec`  Remove
+# one TF 1.0 testing is done or KOKORO jobs are updated to use the
+# tensorfow_pip_spec rather than docker path to control TF version.
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu"
 
 # Pick up some TF dependencies
+# cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
+# really be needed.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         cuda-command-line-tools-10-0 \
         cuda-cublas-10-0 \
+        cuda-cublas-dev-10-0 \
         cuda-cufft-10-0 \
         cuda-curand-10-0 \
         cuda-cusolver-10-0 \
         cuda-cusparse-10-0 \
-        libcudnn7=7.4.1.5-1+cuda10.0 \
+        libcudnn7=7.6.0.64-1+cuda10.0  \
+        libcudnn7-dev=7.6.0.64-1+cuda10.0  \
         libfreetype6-dev \
         libhdf5-serial-dev \
         libzmq3-dev \
@@ -26,10 +35,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl
 
 RUN apt-get update && \
-        apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends libnvinfer5=5.0.2-1+cuda10.0 \
-        && apt-get clean
+    apt-get install -y --no-install-recommends libnvinfer5=5.1.5-1+cuda10.0 \
+    libnvinfer-dev=5.1.5-1+cuda10.0 \
+    && apt-get clean
 
 # For CUDA profiling, TensorFlow requires CUPTI.
 ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
@@ -59,16 +67,18 @@ RUN apt-get install -y --no-install-recommends \
       python3-venv
 
 
-# Setup Python3 environment
-RUN pip3 install --upgrade pip==9.0.1
+# Upgrade pip, need to use pip3 and then pip after this or an error
+# is thrown for no main found.
+RUN pip3 install --upgrade pip
 # setuptools upgraded to fix install requirements from model garden.
-RUN pip3 install wheel
-RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
-RUN pip3 install absl-py
-RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
-RUN pip3 install -U scikit-learn
+RUN pip install wheel
+RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
+RUN pip install absl-py
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec}
+RUN pip install tfds-nightly
+RUN pip install -U scikit-learn
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
-RUN pip3 install -r /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
 
-RUN pip3 freeze
+RUN pip freeze

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -6,15 +6,19 @@ FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
 
 # Pick up some TF dependencies
+# cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
+# really be needed.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         cuda-command-line-tools-10-0 \
         cuda-cublas-10-0 \
+        cuda-cublas-dev-10-0 \
         cuda-cufft-10-0 \
         cuda-curand-10-0 \
         cuda-cusolver-10-0 \
         cuda-cusparse-10-0 \
-        libcudnn7=7.4.1.5-1+cuda10.0 \
+        libcudnn7=7.6.0.64-1+cuda10.0  \
+        libcudnn7-dev=7.6.0.64-1+cuda10.0  \
         libfreetype6-dev \
         libhdf5-serial-dev \
         libzmq3-dev \
@@ -26,10 +30,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl
 
 RUN apt-get update && \
-        apt-get install nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends libnvinfer5=5.0.2-1+cuda10.0 \
-        && apt-get clean
+    apt-get install -y --no-install-recommends libnvinfer5=5.1.5-1+cuda10.0 \
+    libnvinfer-dev=5.1.5-1+cuda10.0 \
+    && apt-get clean
 
 # For CUDA profiling, TensorFlow requires CUPTI.
 ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
@@ -59,17 +62,18 @@ RUN apt-get install -y --no-install-recommends \
       python3-venv
 
 
-# Setup Python3 environment
-RUN pip3 install --upgrade pip==9.0.1
+# Upgrade pip, need to use pip3 and then pip after this or an error
+# is thrown for no main found.
+RUN pip3 install --upgrade pip
 # setuptools upgraded to fix install requirements from model garden.
-RUN pip3 install wheel
-RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
-RUN pip3 install absl-py
-RUN pip3 install --upgrade --force-reinstall ${tensorflow_pip_spec}
-RUN pip3 install tfds-nightly
-RUN pip3 install -U scikit-learn
+RUN pip install wheel
+RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
+RUN pip install absl-py
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec}
+RUN pip install tfds-nightly
+RUN pip install -U scikit-learn
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
-RUN pip3 install -r /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
 
-RUN pip3 freeze
+RUN pip freeze


### PR DESCRIPTION
The nightly TF 2.0 is now using cuDNN 7.6 because this is also needed by the new TensorRT.  We are also moving to manylinux2010 and a newer version of pip is needed to pull that down.