### PR TITLE
allow arbitrary pip specs in PerfZero

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_build
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_build
@@ -5,6 +5,8 @@
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
+ARG extra_pip_specs=""
+ENV EXTRA_PIP_SPECS $(sed 's/;/ /g' <<<$extra_pip_specs)
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -72,7 +74,7 @@ RUN pip3 install --upgrade pip
 RUN pip install wheel
 RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
 RUN pip install absl-py
-RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec}
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec} ${EXTRA_PIP_SPECS}
 RUN pip install tfds-nightly
 RUN pip install -U scikit-learn
 

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_custom_pip
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_custom_pip
@@ -10,6 +10,8 @@ FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 # Location of custom TF pip package, must be relative to docker context.
 # Note that the version tag in the name of wheel file is meaningless.
 ARG tensorflow_pip_spec="resources/tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl"
+ARG extra_pip_specs=""
+ENV EXTRA_PIP_SPECS $(sed 's/;/ /g' <<<$extra_pip_specs)
 
 COPY ${tensorflow_pip_spec} /tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl
 
@@ -74,7 +76,7 @@ RUN pip3 install --upgrade pip==9.0.1
 RUN pip3 install wheel
 RUN pip3 install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery
 RUN pip3 install absl-py
-RUN pip3 install --upgrade --force-reinstall /tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl
+RUN pip3 install --upgrade --force-reinstall /tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl ${EXTRA_PIP_SPECS}
 RUN pip3 install tfds-nightly
 RUN pip3 install -U scikit-learn
 

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
@@ -9,6 +9,8 @@
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu"
+ARG extra_pip_specs=""
+ENV EXTRA_PIP_SPECS $(sed 's/;/ /g' <<<$extra_pip_specs)
 
 # Pick up some TF dependencies
 # cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
@@ -74,7 +76,7 @@ RUN pip3 install --upgrade pip
 RUN pip install wheel
 RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
 RUN pip install absl-py
-RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec}
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec} ${EXTRA_PIP_SPECS}
 RUN pip install tfds-nightly
 RUN pip install -U scikit-learn
 

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -4,6 +4,8 @@
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
+ARG extra_pip_specs=""
+ENV EXTRA_PIP_SPECS $(sed 's/;/ /g' <<<$extra_pip_specs)
 
 # Pick up some TF dependencies
 # cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
@@ -69,7 +71,7 @@ RUN pip3 install --upgrade pip
 RUN pip install wheel
 RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
 RUN pip install absl-py
-RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec}
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec} ${EXTRA_PIP_SPECS}
 RUN pip install tfds-nightly
 RUN pip install -U scikit-learn
 

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -63,6 +63,13 @@ def add_setup_parser_arguments(parser):
       Example values include tf-nightly-gpu, and tensorflow==1.12.0. If it is specified, the corresponding tensorflow pip package/version
       will be installed. Otherwise, the default tensorflow pip package specified in the docker file will be installed.
       ''')
+  parser.add_argument(
+      '--extra_pip_specs',
+      default="",
+      type=str,
+      help='''Additional specifications to pass to `pip install`. (e.g. pinning certain dependencies)
+      Specifications should be semicolon separated: e.g. `numpy==1.16.4;scipy==1.3.1`
+      ''')
 
 
 def add_benchmark_parser_arguments(parser):

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -79,14 +79,18 @@ if __name__ == '__main__':
     # dockerfile_path does not exist
     dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
   docker_tag = 'perfzero/tensorflow'
-  if FLAGS.tensorflow_pip_spec and docker_context:
-    cmd = 'docker build --no-cache --pull -t {} --build-arg tensorflow_pip_spec={} -f {} {}'.format(  # pylint: disable=line-too-long
-        docker_tag, FLAGS.tensorflow_pip_spec, dockerfile_path, docker_context)
-  elif FLAGS.tensorflow_pip_spec:
-    cmd = 'docker build --no-cache --pull -t {} --build-arg tensorflow_pip_spec={} - < {}'.format(  # pylint: disable=line-too-long
-        docker_tag, FLAGS.tensorflow_pip_spec, dockerfile_path)
-  else:
-    cmd = 'docker build --no-cache --pull -t {} - < {}'.format(docker_tag, dockerfile_path)  # pylint: disable=line-too-long
+  cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{extra_pip} {suffix}'.format(
+      docker_tag=docker_tag,
+      tf_pip=(
+          ' --build-arg tensorflow_pip_spec={}'.format(FLAGS.tensorflow_pip_spec)
+          if FLAGS.tensorflow_pip_spec else ''),
+      extra_pip=(
+          ' --build-arg extra_pip_specs={}'.format(FLAGS.extra_pip_specs)
+          if FLAGS.extra_pip_specs else ''),
+      suffix=(
+          '-f {} {}'.format(dockerfile_path, docker_context)
+          if docker_context else '- < {}'.format(dockerfile_path))
+  )
 
   utils.run_commands([cmd])
   logging.info('Built docker image with tag %s', docker_tag)


### PR DESCRIPTION
This is useful for pinning dependencies (e.g. tf-estimator-nightly or numpy) when running tests.