### PR TITLE
Add support to build local .whl files

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_build
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_build
@@ -6,6 +6,9 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
 ARG extra_pip_specs=""
+ARG local_tensorflow_pip_spec=""
+
+COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
 
 # Pick up some TF dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_custom_pip
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_custom_pip
@@ -11,6 +11,9 @@ FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 # Note that the version tag in the name of wheel file is meaningless.
 ARG tensorflow_pip_spec="resources/tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl"
 ARG extra_pip_specs=""
+ARG local_tensorflow_pip_spec=""
+
+COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
 
 COPY ${tensorflow_pip_spec} /tensorflow-0.0.1-cp36-cp36m-linux_x86_64.whl
 

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v1
@@ -10,6 +10,9 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu"
 ARG extra_pip_specs=""
+ARG local_tensorflow_pip_spec=""
+
+COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
 
 # Pick up some TF dependencies
 # cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -8,7 +8,7 @@ ARG local_tensorflow_pip_spec=""
 ARG extra_pip_specs=""
 ARG local_tensorflow_wheel=false
 
-COPY {local_tensorflow_pip_spec} /{local_tensorflow_pip_spec}
+COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
 
 # Pick up some TF dependencies
 # cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -4,9 +4,11 @@
 
 FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
+ARG local_tensorflow_pip_spec=""
 ARG extra_pip_specs=""
+ARG local_tensorflow_wheel=false
 
-RUN /bin/bash -c 'ls -lR'
+COPY {local_tensorflow_pip_spec} /{local_tensorflow_pip_spec}
 
 # Pick up some TF dependencies
 # cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -6,6 +6,8 @@ FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
 ARG extra_pip_specs=""
 
+RUN /bin/bash -c 'ls -lR'
+
 # Pick up some TF dependencies
 # cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
 # really be needed.

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -6,7 +6,6 @@ FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
 ARG local_tensorflow_pip_spec=""
 ARG extra_pip_specs=""
-ARG local_tensorflow_wheel=false
 
 COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
 

--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_v2
@@ -7,6 +7,8 @@ ARG tensorflow_pip_spec="tf-nightly-gpu-2.0-preview"
 ARG local_tensorflow_pip_spec=""
 ARG extra_pip_specs=""
 
+# setup.py passes the base path of local .whl file is chosen for the docker image.
+# Otherwise passes an empty existing file from the context.
 COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
 
 # Pick up some TF dependencies

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -39,7 +39,7 @@ def create_empty_file(parent_directory, file_basename):
     os.makedirs(parent_directory)
   full_file_name = os.path.join(parent_directory, file_basename)
   with open(full_file_name, 'w') as f:
-    print('Creating empty file: {full_file_name}'.format(full_file_name))
+    print('Creating empty file: {}'.format(full_file_name))
     
 
 def checkout_git_repos(git_repos, use_cached_site_packages):

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -27,20 +27,20 @@ import requests
 
 def create_empty_file(parent_directory, file_basename):
   """Creates an empty file with a given basename in a parent directory.
-  
+
   Creates parent_directory and intermediate directories if it doesn't exist.
   This is mostly used for creating no-op actions in the Dockerfile.
-  
+
   Args:
     parent_directory: The path to the parent directory.
-    file_basename: The basename for the empty file.  
+    file_basename: The basename for the empty file.
   """
   if not os.path.isdir(parent_directory):
     os.makedirs(parent_directory)
   full_file_name = os.path.join(parent_directory, file_basename)
-  with open(full_file_name, 'w') as f:
+  with open(full_file_name, 'w'):
     print('Creating empty file: {}'.format(full_file_name))
-    
+
 
 def checkout_git_repos(git_repos, use_cached_site_packages):
   """Clone, update, or sync a repo.

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -25,6 +25,23 @@ import traceback
 import requests
 
 
+def create_empty_file(parent_directory, file_basename):
+  """Creates an empty file with a given basename in a parent directory.
+  
+  Creates parent_directory and intermediate directories if it doesn't exist.
+  This is mostly used for creating no-op actions in the Dockerfile.
+  
+  Args:
+    parent_directory: The path to the parent directory.
+    file_basename: The basename for the empty file.  
+  """
+  if not os.path.isdir(parent_directory):
+    os.makedirs(parent_directory)
+  full_file_name = os.path.join(parent_directory, file_basename)
+  with open(full_file_name, 'w') as f:
+    print('Creating empty file: {full_file_name}'.format(full_file_name))
+    
+
 def checkout_git_repos(git_repos, use_cached_site_packages):
   """Clone, update, or sync a repo.
 

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -26,7 +26,7 @@ import perfzero.device_utils as device_utils
 import perfzero.perfzero_config as perfzero_config
 import perfzero.utils as utils
 
-
+    
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -58,14 +58,18 @@ if __name__ == '__main__':
 
   # Create docker image
   start_time = time.time()
-  docker_context = None
+  
 
   # Download TensorFlow pip package from Google Cloud Storage and modify package
   # path accordingly, if applicable
+  local_tensorflow_pip_spec = None
+  docker_context = os.path.join(workspace_dir, 'resources')
+  # Necessary in case we don't have a local .whl file.
+  utils.create_empty_file(docker_context, 'EMPTY')
+  
   if (FLAGS.tensorflow_pip_spec and
       (FLAGS.tensorflow_pip_spec.startswith('gs://') or
-       FLAGS.tensorflow_pip_spec.startswith('file://'))):
-    docker_context = os.path.join(workspace_dir, 'resources')
+       FLAGS.tensorflow_pip_spec.startswith('file://'))):  
     local_pip_filename = os.path.basename(FLAGS.tensorflow_pip_spec)
     local_pip_path = os.path.join(docker_context, local_pip_filename)
     utils.download_data([{'url': FLAGS.tensorflow_pip_spec,
@@ -73,6 +77,9 @@ if __name__ == '__main__':
     # Update path to pip wheel file for the Dockerfile. Note that this path has
     # to be relative to the docker context (absolute path will not work).
     FLAGS.tensorflow_pip_spec = local_pip_filename
+    local_tensorflow_pip_spec = local_pip_filename     
+  else:
+    local_tensorflow_pip_spec = 'EMPTY'
 
   dockerfile_path = FLAGS.dockerfile_path
   if not os.path.exists(dockerfile_path):
@@ -81,11 +88,13 @@ if __name__ == '__main__':
     dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
   docker_tag = 'perfzero/tensorflow'
   extra_pip_specs = (FLAGS.extra_pip_specs or '').replace(';', '')
-  cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{extra_pip} {suffix}'.format(
+  cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{local_tf_pip}{extra_pip} {suffix}'.format(
       docker_tag=docker_tag,
       tf_pip=(
           ' --build-arg tensorflow_pip_spec={}'.format(FLAGS.tensorflow_pip_spec)
           if FLAGS.tensorflow_pip_spec else ''),
+      # local_tensorflow_pip_spec is either 'EMPTY' or basename of local .whl file.
+      local_tf_pip=' --build-arg local_tensorflow_pip_spec={}'.format(local_tensorflow_pip_spec),
       extra_pip=' --build-arg extra_pip_specs=\'{}\''.format(extra_pip_specs),
       suffix=(
           '-f {} {}'.format(dockerfile_path, docker_context)

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -63,7 +63,8 @@ if __name__ == '__main__':
   # Download TensorFlow pip package from Google Cloud Storage and modify package
   # path accordingly, if applicable
   if (FLAGS.tensorflow_pip_spec and
-      FLAGS.tensorflow_pip_spec.startswith('gs://')):
+      (FLAGS.tensorflow_pip_spec.startswith('gs://') or
+       FLAGS.tensorflow_pip_spec.startswith('file://'))):
     docker_context = os.path.join(workspace_dir, 'resources')
     local_pip_filename = os.path.basename(FLAGS.tensorflow_pip_spec)
     local_pip_path = os.path.join(docker_context, local_pip_filename)

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
   # Download TensorFlow pip package from Google Cloud Storage and modify package
   # path accordingly, if applicable
   local_tensorflow_pip_spec = None
-  
+
   if (FLAGS.tensorflow_pip_spec and
       (FLAGS.tensorflow_pip_spec.startswith('gs://') or
        FLAGS.tensorflow_pip_spec.startswith('file://'))):
@@ -86,15 +86,17 @@ if __name__ == '__main__':
     dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
   docker_tag = 'perfzero/tensorflow'
   extra_pip_specs = (FLAGS.extra_pip_specs or '').replace(';', '')
-  cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{local_tf_pip}{extra_pip} {suffix}'.format(
+  docker_base_cmd = 'docker build --no-cache --pull'
+  cmd = '{docker_base_cmd} -t {docker_tag}{tf_pip}{local_tf_pip}{extra_pip} {suffix}'.format(
+      docker_base_cmd=docker_base_cmd,
       docker_tag=docker_tag,
       tf_pip=(
           ' --build-arg tensorflow_pip_spec={}'.format(
-            FLAGS.tensorflow_pip_spec) if FLAGS.tensorflow_pip_spec else ''),
+              FLAGS.tensorflow_pip_spec) if FLAGS.tensorflow_pip_spec else ''),
       # local_tensorflow_pip_spec is either string 'EMPTY' or basename of
       # local .whl file.
       local_tf_pip=' --build-arg local_tensorflow_pip_spec={}'.format(
-        local_tensorflow_pip_spec),
+          local_tensorflow_pip_spec),
       extra_pip=' --build-arg extra_pip_specs=\'{}\''.format(extra_pip_specs),
       suffix=(
           '-f {} {}'.format(dockerfile_path, docker_context)

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -26,7 +26,6 @@ import perfzero.device_utils as device_utils
 import perfzero.perfzero_config as perfzero_config
 import perfzero.utils as utils
 
-    
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(
       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -58,14 +57,13 @@ if __name__ == '__main__':
 
   # Create docker image
   start_time = time.time()
-  
+  docker_context = os.path.join(workspace_dir, 'resources')
+  # Necessary in case we don't have a local .whl file.
+  utils.create_empty_file(docker_context, 'EMPTY')
 
   # Download TensorFlow pip package from Google Cloud Storage and modify package
   # path accordingly, if applicable
   local_tensorflow_pip_spec = None
-  docker_context = os.path.join(workspace_dir, 'resources')
-  # Necessary in case we don't have a local .whl file.
-  utils.create_empty_file(docker_context, 'EMPTY')
   
   if (FLAGS.tensorflow_pip_spec and
       (FLAGS.tensorflow_pip_spec.startswith('gs://') or

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -84,8 +84,7 @@ if __name__ == '__main__':
   cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{extra_pip} {suffix}'.format(
       docker_tag=docker_tag,
       tf_pip=(
-          ' --build-arg tensorflow_pip_spec={} --build-arg local_tensorflow_pip_spec={}'.format(
-            FLAGS.tensorflow_pip_spec, FLAGS.tensorflow_pip_spec)
+          ' --build-arg tensorflow_pip_spec={}'.format(FLAGS.tensorflow_pip_spec)
           if FLAGS.tensorflow_pip_spec else ''),
       extra_pip=' --build-arg extra_pip_specs=\'{}\''.format(extra_pip_specs),
       suffix=(

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
       tf_pip=(
           ' --build-arg tensorflow_pip_spec={}'.format(FLAGS.tensorflow_pip_spec)
           if FLAGS.tensorflow_pip_spec else ''),
-      # local_tensorflow_pip_spec is either 'EMPTY' or basename of local .whl file.
+      # local_tensorflow_pip_spec is either string 'EMPTY' or basename of local .whl file.
       local_tf_pip=' --build-arg local_tensorflow_pip_spec={}'.format(local_tensorflow_pip_spec),
       extra_pip=' --build-arg extra_pip_specs=\'{}\''.format(extra_pip_specs),
       suffix=(

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
   
   if (FLAGS.tensorflow_pip_spec and
       (FLAGS.tensorflow_pip_spec.startswith('gs://') or
-       FLAGS.tensorflow_pip_spec.startswith('file://'))):  
+       FLAGS.tensorflow_pip_spec.startswith('file://'))):
     local_pip_filename = os.path.basename(FLAGS.tensorflow_pip_spec)
     local_pip_path = os.path.join(docker_context, local_pip_filename)
     utils.download_data([{'url': FLAGS.tensorflow_pip_spec,
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     # Update path to pip wheel file for the Dockerfile. Note that this path has
     # to be relative to the docker context (absolute path will not work).
     FLAGS.tensorflow_pip_spec = local_pip_filename
-    local_tensorflow_pip_spec = local_pip_filename     
+    local_tensorflow_pip_spec = local_pip_filename
   else:
     local_tensorflow_pip_spec = 'EMPTY'
 
@@ -89,10 +89,12 @@ if __name__ == '__main__':
   cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{local_tf_pip}{extra_pip} {suffix}'.format(
       docker_tag=docker_tag,
       tf_pip=(
-          ' --build-arg tensorflow_pip_spec={}'.format(FLAGS.tensorflow_pip_spec)
-          if FLAGS.tensorflow_pip_spec else ''),
-      # local_tensorflow_pip_spec is either string 'EMPTY' or basename of local .whl file.
-      local_tf_pip=' --build-arg local_tensorflow_pip_spec={}'.format(local_tensorflow_pip_spec),
+          ' --build-arg tensorflow_pip_spec={}'.format(
+            FLAGS.tensorflow_pip_spec) if FLAGS.tensorflow_pip_spec else ''),
+      # local_tensorflow_pip_spec is either string 'EMPTY' or basename of
+      # local .whl file.
+      local_tf_pip=' --build-arg local_tensorflow_pip_spec={}'.format(
+        local_tensorflow_pip_spec),
       extra_pip=' --build-arg extra_pip_specs=\'{}\''.format(extra_pip_specs),
       suffix=(
           '-f {} {}'.format(dockerfile_path, docker_context)

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -84,7 +84,8 @@ if __name__ == '__main__':
   cmd = 'docker build --no-cache --pull -t {docker_tag}{tf_pip}{extra_pip} {suffix}'.format(
       docker_tag=docker_tag,
       tf_pip=(
-          ' --build-arg tensorflow_pip_spec={}'.format(FLAGS.tensorflow_pip_spec)
+          ' --build-arg tensorflow_pip_spec={} --build-arg local_tensorflow_pip_spec={}'.format(
+            FLAGS.tensorflow_pip_spec, FLAGS.tensorflow_pip_spec)
           if FLAGS.tensorflow_pip_spec else ''),
       extra_pip=' --build-arg extra_pip_specs=\'{}\''.format(extra_pip_specs),
       suffix=(


### PR DESCRIPTION
Allow passing --tensorflow_pip_spec=file://dir1/dir2/local_path.whl to setup.py. 

This translates to running docker build (in setup.py) with:
  - --tensorflow_pip_spec=local_path.whl --local_tensorflow_pip_spec=local_path.whl for local or gs:// files.
  - --tensorflow_pip_spec=[path] --local_tensorflow_pip_spec=EMPTY 
if [path] doesn't start with gs:// or file://.
A file called EMPTY will always be present in the docker context.
COPY command in dockerfile makes [context-dir]/<local_tensorflow_pip_spec> available.


Adds a build-arg "local_tensorflow_pip_spec" to all Dockerfiles (which is copied from docker_context to / by the Dockerfile) to be compatible.

Conditional COPY is not supported (https://stackoverflow.com/questions/31528384/conditional-copy-add-in-dockerfile) so we either pass --local_tensorflow_pip_spec=EMPTY (with a file called EMPTY in the context) or --local_tensorflow_pip_spec=local_file.whl (with local_file.whl existing in the context)