### PR TITLE
Add option to load a docker image if provided.

### DIFF
--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -193,8 +193,9 @@ def download_data(download_infos):
           os.path.join(local_path_parent, expected_base_name))])
     logging.info('Downloaded data from %s to %s',
                  info['url'], info['local_path'])
-    # Decompress file if file name ends with .gz
-    if info['url'].endswith('.gz'):
+    # Decompress file if file name ends with .gz unless caller sets 'decompress'
+    # to False in info.
+    if info['url'].endswith('.gz') and info.get('decompress', True):
       run_commands(['tar xvf {} -C {}'.format(
           info['local_path'], local_path_parent)])
       logging.info('Decompressed file %s', info['local_path'])
@@ -376,4 +377,3 @@ def instantiate_benchmark_class(benchmark_class, output_dir, root_data_dir):
   instance = class_(output_dir=output_dir, root_data_dir=root_data_dir)
 
   return instance
-

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
   workspace_dir = os.path.join(project_dir, FLAGS.workspace)
 
   activate_gcloud = False
-  if FLAGS.dockerfile_path.startswith('gs://'):
+  if FLAGS.dockerfile_path and FLAGS.dockerfile_path.startswith('gs://'):
     # We might end up doing gsutil fetch later, so need to call
     # active_gcloud_service().
     activate_gcloud = True


### PR DESCRIPTION
Currently we save a docker image if --dockerfile_path=Dockerfile_Ubuntu_...
If we have a pre-setup docker, we should able to load it with --dockerfile_path=saved_image.tar.gz
- (let me know if you think --dockerimage_path as a new flag is more appropriate).

- We meed to activate gcloud auth if --dockerfile_path (or --dockerimage-path) or --tensorflow_pip_spec start with gs:/;
- Also skip decompressing the image, if we download a .tar.gz file.

