### PR TITLE
Add dockerfiles for Swift for TensorFlow

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.0
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.0
@@ -1,0 +1,121 @@
+# Ubuntu 18.04 Python3 with CUDA 10 and the following:
+#  - Installs tf-nightly-gpu (this is TF 2.0)
+#  - Installs requirements.txt for tensorflow/models
+# Additionally also installs:
+#  - Latest S4TF development snapshot for cuda 10.0
+
+FROM nvidia/cuda:10.0-base-ubuntu18.04 as base
+ARG tensorflow_pip_spec="tf-nightly-gpu"
+ARG local_tensorflow_pip_spec=""
+ARG extra_pip_specs=""
+ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.0-cudnn7-ubuntu18.04.tar.gz
+
+# setup.py passes the base path of local .whl file is chosen for the docker image.
+# Otherwise passes an empty existing file from the context.
+COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
+
+# Pick up some TF dependencies
+# cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
+# really be needed.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cuda-command-line-tools-10-0 \
+        cuda-cublas-10-0 \
+        cuda-cublas-dev-10-0 \
+        cuda-cufft-10-0 \
+        cuda-curand-10-0 \
+        cuda-cusolver-10-0 \
+        cuda-cusparse-10-0 \
+        libcudnn7=7.6.2.24-1+cuda10.0  \
+        libcudnn7-dev=7.6.2.24-1+cuda10.0  \
+        libfreetype6-dev \
+        libhdf5-serial-dev \
+        libzmq3-dev \
+        libpng-dev \
+        pkg-config \
+        software-properties-common \
+        unzip \
+        lsb-core \
+        curl
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libnvinfer5=5.1.5-1+cuda10.0 \
+    libnvinfer-dev=5.1.5-1+cuda10.0 \
+    && apt-get clean
+
+# For CUDA profiling, TensorFlow requires CUPTI.
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+# Add google-cloud-sdk to the source list
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+# Install extras needed by most models
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      wget \
+      htop \
+      zip \
+      google-cloud-sdk
+
+# Install / update Python and Python3
+RUN apt-get install -y --no-install-recommends \
+      python3 \
+      python3-dev \
+      python3-pip \
+      python3-setuptools \
+      python3-venv
+
+
+# Upgrade pip, need to use pip3 and then pip after this or an error
+# is thrown for no main found.
+RUN pip3 install --upgrade pip
+# setuptools upgraded to fix install requirements from model garden.
+RUN pip install wheel
+RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
+RUN pip install absl-py
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec} ${extra_pip_specs}
+RUN pip install tfds-nightly
+RUN pip install -U scikit-learn
+
+RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+RUN pip freeze
+
+### Install Swift deps.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python \
+        python-dev \
+        python-pip \
+        python-setuptools \
+        python-tk \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        clang \
+        libcurl4-openssl-dev \
+        libicu-dev \
+        libpython-dev \
+        libpython3-dev \
+        libncurses5-dev \
+        libxml2 \
+        libblocksruntime-dev
+
+# Download and extract S4TF
+WORKDIR /swift-tensorflow-toolchain
+RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
+    && mkdir usr \
+    && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
+    && rm swift.tar.gz
+ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/swift-tensorflow-toolchain/usr/lib/swift/linux/:${LD_LIBRARY_PATH}"

--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
@@ -1,0 +1,130 @@
+# Ubuntu 18.04 Python3 with CUDA 10.1 and the following:
+#  - Installs tf-nightly-gpu (this is TF 2.1)
+#  - Installs requirements.txt for tensorflow/models
+#  - TF 2.0 tested with cuda 10.0, but we need to test tf 2.1 with cuda 10.1.
+# Additionally also installs
+#  - Latest S4TF development snapshot for cuda 10.1
+
+FROM nvidia/cuda:10.1-base-ubuntu18.04 as base
+ARG tensorflow_pip_spec="tf-nightly-gpu"
+ARG local_tensorflow_pip_spec=""
+ARG extra_pip_specs=""
+ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz
+
+# setup.py passes the base path of local .whl file is chosen for the docker image.
+# Otherwise passes an empty existing file from the context.
+COPY ${local_tensorflow_pip_spec} /${local_tensorflow_pip_spec}
+
+# Pick up some TF dependencies
+# cublas-dev and libcudnn7-dev only needed because of libnvinfer-dev which may not
+# really be needed.
+# In the future, add the following lines in a shell script running on the
+# benchmark vm to get the available dependent versions when updating cuda
+# version (e.g to 10.2 or something later):
+# sudo apt-cache search cuda-command-line-tool
+# sudo apt-cache search cuda-cublas
+# sudo apt-cache search cuda-cufft
+# sudo apt-cache search cuda-curand
+# sudo apt-cache search cuda-cusolver
+# sudo apt-cache search cuda-cusparse
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cuda-command-line-tools-10-1 \
+        cuda-cufft-10-1 \
+        cuda-curand-10-1 \
+        cuda-cusolver-10-1 \
+        cuda-cusparse-10-1 \
+        libcudnn7=7.6.4.38-1+cuda10.1  \
+        libcudnn7-dev=7.6.4.38-1+cuda10.1  \
+        libfreetype6-dev \
+        libhdf5-serial-dev \
+        libzmq3-dev \
+        libpng-dev \
+        pkg-config \
+        software-properties-common \
+        unzip \
+        lsb-core \
+        curl
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libnvinfer5=5.1.5-1+cuda10.1 \
+    libnvinfer-dev=5.1.5-1+cuda10.1 \
+    libnvinfer6=6.0.1-1+cuda10.1 \
+    && apt-get clean
+
+# For CUDA profiling, TensorFlow requires CUPTI.
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH
+
+# See http://bugs.python.org/issue19846
+ENV LANG C.UTF-8
+
+# Add google-cloud-sdk to the source list
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+# Install extras needed by most models
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      wget \
+      htop \
+      zip \
+      google-cloud-sdk
+
+# Install / update Python and Python3
+RUN apt-get install -y --no-install-recommends \
+      python3 \
+      python3-dev \
+      python3-pip \
+      python3-setuptools \
+      python3-venv
+
+# Upgrade pip, need to use pip3 and then pip after this or an error
+# is thrown for no main found.
+RUN pip3 install --upgrade pip
+# setuptools upgraded to fix install requirements from model garden.
+RUN pip install wheel
+RUN pip install --upgrade setuptools google-api-python-client pyyaml google-cloud google-cloud-bigquery mock
+RUN pip install absl-py
+RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec} ${extra_pip_specs}
+RUN pip install tfds-nightly
+RUN pip install -U scikit-learn
+
+RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+RUN pip freeze
+
+### Install Swift deps.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python \
+        python-dev \
+        python-pip \
+        python-setuptools \
+        python-tk \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        clang \
+        libcurl4-openssl-dev \
+        libicu-dev \
+        libpython-dev \
+        libpython3-dev \
+        libncurses5-dev \
+        libxml2 \
+        libblocksruntime-dev
+
+# Download and extract S4TF
+WORKDIR /swift-tensorflow-toolchain
+RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
+    && mkdir usr \
+    && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
+    && rm swift.tar.gz
+ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/swift-tensorflow-toolchain/usr/lib/swift/linux/:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
This PR adds 2 new dockerfile configurations created to test Swift for TensorFlow models:

1. Cuda 10.0 (based on TF2 dockerfile)
2. Cuda 10.1 (based on TF2.1 dockerfile)

This change is intended to be used with our upcoming perfzero integration in [swift-models#236](https://github.com/tensorflow/swift-models/pull/236).

Sample output for perfzero when used with swift-models can be found [here](https://gist.github.com/shabalind/b70a40e08ff39604b790a60d1003d5bb).