### PR TITLE
Pass TPU name in benchmark class instantiation

### DIFF
--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -94,7 +94,8 @@ class BenchmarkRunner(object):
         pattern = benchmark_method_pattern[index + len(filter_prefix):]
         class_instance = utils.instantiate_benchmark_class(benchmark_class,
                                                            '/dev/null',
-                                                           '')
+                                                           '',
+                                                           None)
         for benchmark_method_name in dir(class_instance):
           if re.match(pattern, benchmark_method_name):
             benchmark_methods.append(benchmark_class + '.' +

--- a/perfzero/lib/perfzero/benchmark_method_runner.py
+++ b/perfzero/lib/perfzero/benchmark_method_runner.py
@@ -74,8 +74,12 @@ def _run_internal(benchmark_method, harness_info, site_package_info,
   logging.getLogger().addHandler(filehandler)
 
   try:
+    if config.tpu_parameters:
+      tpu = config.tpu_parameters.get('name')
+    else:
+      tpu = None
     class_instance = utils.instantiate_benchmark_class(
-        benchmark_class, output_dir, config.root_data_dir)
+        benchmark_class, output_dir, config.root_data_dir, tpu=tpu)
     # tf.test.Benchmark.report_benchmark() writes results to a file with
     # path benchmark_result_file_path_prefix + benchmark_method
     benchmark_result_file_path_prefix = os.path.join(output_dir, 'proto_')

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -445,12 +445,12 @@ def print_thread_stacktrace():
     traceback.print_stack(frame)
 
 
-def instantiate_benchmark_class(benchmark_class, output_dir, root_data_dir):
+def instantiate_benchmark_class(benchmark_class, output_dir, root_data_dir, tpu):
   """Return initialized benchmark class."""
   module_import_path, class_name = benchmark_class.rsplit('.', 1)
   module = importlib.import_module(module_import_path)
   class_ = getattr(module, class_name)
-  instance = class_(output_dir=output_dir, root_data_dir=root_data_dir)
+  instance = class_(output_dir=output_dir, root_data_dir=root_data_dir, tpu=tpu)
 
   return instance
 


### PR DESCRIPTION
Tested:
(1) with TPU benchmark, non-empty tpu arg is used
(2) with CPU benchmark, empty tpu arg is ignored