### PR TITLE
Add a command line option to enable automatic mixed precision.

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -672,6 +672,9 @@ flags.DEFINE_string('benchmark_test_id', None,
                     'different test runs. This flag is designed for human '
                     'consumption, and does not have any impact within the '
                     'system.')
+flags.DEFINE_boolean('auto_mixed_precision', False,
+                     'enable/disable grappler optimization that implements'
+                     'automatic mixed precision support.')
 
 platforms_util.define_platform_params()
 
@@ -799,6 +802,9 @@ def create_config_proto(params):
   # OOM/perf cliffs.
   config.graph_options.rewrite_options.pin_to_host_optimization = (
       rewriter_config_pb2.RewriterConfig.OFF)
+  if params.auto_mixed_precision:
+    config.graph_options.rewrite_options.auto_mixed_precision = (
+      rewriter_config_pb2.RewriterConfig.ON)
   return config
 
 


### PR DESCRIPTION
This PR/commit adds a command line option `auto_mixed_precision` to enable AMP (automatic mixed precision) for the tf_cnn_benchmarks. Based on the information given here : https://www.tensorflow.org/api_docs/python/tf/train/experimental/enable_mixed_precision_graph_rewrite