### PR TITLE
Add perfzero_constructor_args flag

### DIFF
--- a/perfzero/lib/benchmark.py
+++ b/perfzero/lib/benchmark.py
@@ -95,7 +95,8 @@ class BenchmarkRunner(object):
         class_instance = utils.instantiate_benchmark_class(benchmark_class,
                                                            '/dev/null',
                                                            '',
-                                                           None)
+                                                           None,
+                                                           {})
         for benchmark_method_name in dir(class_instance):
           if re.match(pattern, benchmark_method_name):
             benchmark_methods.append(benchmark_class + '.' +

--- a/perfzero/lib/perfzero/benchmark_method_runner.py
+++ b/perfzero/lib/perfzero/benchmark_method_runner.py
@@ -88,11 +88,16 @@ def _run_internal(benchmark_method, harness_info, site_package_info,
       tpu = config.tpu_parameters.get('name')
     else:
       tpu = None
+    if config.perfzero_contructor_args:
+      benchmark_args = json.loads(config.perfzero_contructor_args)
+    else:
+      benchmark_args = {}
     class_instance = utils.instantiate_benchmark_class(
         benchmark_class=benchmark_class,
         output_dir=model_output_dir,
         root_data_dir=config.root_data_dir,
-        tpu=tpu)
+        tpu=tpu,
+        benchmark_args = benchmark_args)
     # tf.test.Benchmark.report_benchmark() writes results to a file with
     # path benchmark_result_file_path_prefix + benchmark_method
     benchmark_result_file_path_prefix = os.path.join(output_dir, 'proto_')

--- a/perfzero/lib/perfzero/benchmark_method_runner.py
+++ b/perfzero/lib/perfzero/benchmark_method_runner.py
@@ -89,15 +89,15 @@ def _run_internal(benchmark_method, harness_info, site_package_info,
     else:
       tpu = None
     if config.perfzero_contructor_args:
-      benchmark_args = json.loads(config.perfzero_contructor_args)
+      constructor_args = json.loads(config.perfzero_contructor_args)
     else:
-      benchmark_args = {}
+      constructor_args = {}
     class_instance = utils.instantiate_benchmark_class(
         benchmark_class=benchmark_class,
         output_dir=model_output_dir,
         root_data_dir=config.root_data_dir,
         tpu=tpu,
-        benchmark_args = benchmark_args)
+        constructor_args=constructor_args)
     # tf.test.Benchmark.report_benchmark() writes results to a file with
     # path benchmark_result_file_path_prefix + benchmark_method
     benchmark_result_file_path_prefix = os.path.join(output_dir, 'proto_')

--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -257,6 +257,14 @@ def add_benchmark_parser_arguments(parser):
       help='''A json dictionary of cloud tpu parameters. The format must look like the following:
       {"name": "my-tpu-name", project": "my-gcp-project-id", "zone": "europe-west4-a", "size": "v3-8", "version": "nightly-2.x"}
       ''')
+  parser.add_argument(
+      '--perfzero_contructor_args',
+      nargs='*',
+      default='',
+      type=str,
+      help='''A json dictionary of additional args to pass to the perfzero
+           constructor.'''
+  )
 
 
 class PerfZeroConfig(object):

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -445,12 +445,17 @@ def print_thread_stacktrace():
     traceback.print_stack(frame)
 
 
-def instantiate_benchmark_class(benchmark_class, output_dir, root_data_dir, tpu):
+def instantiate_benchmark_class(
+    benchmark_class, output_dir, root_data_dir, tpu, benchmark_args):
   """Return initialized benchmark class."""
   module_import_path, class_name = benchmark_class.rsplit('.', 1)
   module = importlib.import_module(module_import_path)
   class_ = getattr(module, class_name)
-  instance = class_(output_dir=output_dir, root_data_dir=root_data_dir, tpu=tpu)
+  instance = class_(
+      output_dir=output_dir,
+      root_data_dir=root_data_dir,
+      tpu=tpu,
+      **benchmark_args)
 
   return instance
 

--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -446,7 +446,7 @@ def print_thread_stacktrace():
 
 
 def instantiate_benchmark_class(
-    benchmark_class, output_dir, root_data_dir, tpu, benchmark_args):
+    benchmark_class, output_dir, root_data_dir, tpu, constructor_args):
   """Return initialized benchmark class."""
   module_import_path, class_name = benchmark_class.rsplit('.', 1)
   module = importlib.import_module(module_import_path)
@@ -455,7 +455,7 @@ def instantiate_benchmark_class(
       output_dir=output_dir,
       root_data_dir=root_data_dir,
       tpu=tpu,
-      **benchmark_args)
+      **constructor_args)
 
   return instance
 


### PR DESCRIPTION
Add perfzero_constructor_args flag. This flag can be used to pass a map of arguments to the benchmark constructor.