### PR TITLE
State tf_cnn_benchmarks is unmaintained in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains various TensorFlow benchmarks. Currently, it consists o
 
 1. [PerfZero](https://github.com/tensorflow/benchmarks/tree/master/perfzero): A benchmark framework for TensorFlow.
 
-2. [scripts/tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks): The TensorFlow CNN benchmarks contain benchmarks for several convolutional neural networks.
+2. [scripts/tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks) (no longer maintained): The TensorFlow CNN benchmarks contain TensorFlow 1 benchmarks for several convolutional neural networks.
 
-
+If you want to run TensorFlow models and measure their performance, also consider the [TensorFlow Official Models](https://github.com/tensorflow/models/tree/master/official)
 


### PR DESCRIPTION
Also mention the official models, which is an easy way of measuring performance.