### PR TITLE
Add pbtxt format support for partition graph

### DIFF
--- a/scripts/tf_cnn_benchmarks/benchmark_cnn.py
+++ b/scripts/tf_cnn_benchmarks/benchmark_cnn.py
@@ -922,7 +922,7 @@ def benchmark_one_step(sess,
         ext = '.' + ext
       else:
         base_filename, ext = filename, ''
-      as_text = filename.endswith('txt')
+      as_text = filename.endswith('txt') or filename.endswith('pbtxt')
       for graph_def in run_metadata.partition_graphs:
         device = graph_def.node[0].device.replace('/', '_').replace(':', '_')
         graph_filename = '%s%s%s' % (base_filename, device, ext)


### PR DESCRIPTION
Add .pbtxt to the text format for partition graph, because only this format can be read by tensorboard.

Thank you for your time on reviewing this pr.