### PR TITLE
Add retry to curl downloads within Swift for TensorFlow Dockerfiles

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.0
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.0
@@ -113,8 +113,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
-    && mkdir usr \
+RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    then sleep 30 && curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    fi;
+
+RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gz
 ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"

--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
@@ -128,6 +128,6 @@ RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
 
 RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
-    && rm swift.tar.gzENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
+    && rm swift.tar.gz
 ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/swift-tensorflow-toolchain/usr/lib/swift/linux/:${LD_LIBRARY_PATH}"

--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
@@ -129,4 +129,5 @@ RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
 RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
     && rm swift.tar.gzENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
+ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/swift-tensorflow-toolchain/usr/lib/swift/linux/:${LD_LIBRARY_PATH}"

--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
@@ -122,9 +122,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Download and extract S4TF
 WORKDIR /swift-tensorflow-toolchain
-RUN curl -fSsL $swift_tf_url -o swift.tar.gz \
-    && mkdir usr \
+RUN if ! curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    then sleep 30 && curl -fSsL --retry 5 $swift_tf_url -o swift.tar.gz; \
+    fi;
+
+RUN mkdir usr \
     && tar -xzf swift.tar.gz --directory=usr --strip-components=1 \
-    && rm swift.tar.gz
-ENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
+    && rm swift.tar.gzENV PATH="/swift-tensorflow-toolchain/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/swift-tensorflow-toolchain/usr/lib/swift/linux/:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
We've been experiencing an uptick in OpenSSL failures on the downloads for the Swift for TensorFlow nightly toolchains during our CI runs. Detecting a failure and adding a delayed retry seems to significantly cut down on failed CI runs.

This propagates that fix to the Dockerfiles used for our nightly benchmarks, which should hopefully make our nightly benchmarks more robust.