### PR TITLE
Updating `get_gpu_info()` to support AMD GPUs

### DIFF
--- a/perfzero/lib/perfzero/utils.py
+++ b/perfzero/lib/perfzero/utils.py
@@ -24,6 +24,8 @@ import sys
 import threading
 import traceback
 import requests
+import json
+import re
 
 def create_empty_file(parent_directory, file_basename):
   """Creates an empty file with a given basename in a parent directory.
@@ -311,7 +313,51 @@ def get_cpu_socket_count():
     return -1
 
 
-def get_gpu_info():
+def _get_amd_gpu_info():
+  """Returns gpu information using rocm-smi.
+
+  Note: Assumes if the system has multiple GPUs, that they are all the same
+
+  Returns:
+    A dict containing gpu_driver_version, gpu_model and gpu_count or None if
+    `rocm-smi` is not found or fails.
+  """
+  cmd = 'rocm-smi --json --showproductname --showdriverversion'
+  exit_code, result = run_command(cmd)
+
+  if exit_code != 0:
+    logging.error('rocm-smi did not return as expected: %s', result)
+    return None
+
+  def get_gpu_driver_version(rocm_smi_output):
+    return rocm_smi_output['system']['Driver version']
+
+  def get_gpu_model(rocm_smi_output):
+    gpu_model = ""
+    for key, value in rocm_smi_output.items():
+      if re.match("card[0-9]+", key):
+        gpu_model = value['Card SKU']
+        break
+    return gpu_model
+
+  def get_gpu_count(rocm_smi_output):
+    gpu_count = 0
+    for key, value in rocm_smi_output.items():
+      if re.match("card[0-9]+", key):
+        gpu_count += 1
+    return gpu_count
+
+  rocm_smi_output= json.loads(result)
+
+  gpu_info = {}
+  gpu_info['gpu_driver_version'] = get_gpu_driver_version(rocm_smi_output)
+  gpu_info['gpu_model'] = get_gpu_model(rocm_smi_output)
+  gpu_info['gpu_count'] = get_gpu_count(rocm_smi_output)
+
+  return gpu_info
+
+
+def _get_nvidia_gpu_info():
   """Returns gpu information using nvidia-smi.
 
   Note: Assumes if the system has multiple GPUs that they are all the same with
@@ -340,6 +386,17 @@ def get_gpu_info():
   gpu_info['gpu_count'] = len(lines) - 1
 
   return gpu_info
+
+
+def get_gpu_info():
+  """Returns gpu information using either nvidia-smi or rocm-smi.
+
+  Returns:
+    A dict containing gpu_driver_version, gpu_model and gpu_count or None if
+    `nvidia-smi` is not found or fails.
+  """
+  return _get_amd_gpu_info() if shutil.which("rocm-smi") \
+    else _get_nvidia_gpu_info()
 
 
 def _install_tpu_tool():


### PR DESCRIPTION
This PR/commit updates the `get_gpu_info` routine (within `utils.py`) to support AMD GPUs.

The `get_gpu_info` routine now checks for the present of `rocm-smi` (equivalent of `nvidia-smi` for AMD GPUs) in the PATH
If found, then it will call `rocm-smi` to get the AMD GPU specific info,
Else if will call the `nvidia-smi` to get the NVIDIA GPU specific info.

Similar to the case for NVIDIA GPUs, the code assumes that if the system has multiple GPUs, then they are all the same.

------------------------------------

/cc @sunway513 