### PR TITLE
Add pip dependencies needed to use tf.distribute test utils

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_cuda_11
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_cuda_11
@@ -77,6 +77,8 @@ RUN pip install absl-py
 RUN pip install --upgrade --force-reinstall ${tensorflow_pip_spec} ${extra_pip_specs}
 RUN pip install tfds-nightly
 RUN pip install -U scikit-learn
+# Install dependnecies needed for tf.distribute test utils
+RUN pip install dill tblib portpicker
 
 RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/requirements.txt > /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt


### PR DESCRIPTION
Replicate commit (https://github.com/tensorflow/benchmarks/commit/3effceb5d57dcd24810ed8674b88ed5edaff4988) to cuda11 docker.