### PR TITLE
--no-docker_pull prevents looking at remote repositories.

### DIFF
--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -97,6 +97,23 @@ def add_setup_parser_arguments(parser):
       --build-arg arg0 --build-arg arg1=value1 --build-arg "arg2=value with space" --build-arg arg3=300
       '''
       )
+  parser.add_argument(
+      '--docker_pull',
+      action='store_true',
+      dest='docker_pull',
+      help='''Set to check remote repositories for updated images. This is the
+      default. Use --no-docker_pull for the opposite.
+      '''
+      )
+  parser.add_argument(
+      '--no-docker_pull',
+      action='store_false',
+      dest='docker_pull',
+      help='''Set to skip checking remote repositories for updated images. This
+      is useful if the base image has been created locally.
+      '''
+      )
+  parser.set_defaults(docker_pull=True)
 
 
 def add_benchmark_parser_arguments(parser):
@@ -343,7 +360,7 @@ class PerfZeroConfig(object):
       if value is not None:
         not_none_flags[key] = value
     return not_none_flags
-  
+
   def get_git_repos(self, site_packages_dir):
     """Parse git repository string."""
     git_repos = []

--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -114,7 +114,9 @@ def _create_docker_image(FLAGS, project_dir, workspace_dir,
     # dockerfile_path does not exist
     dockerfile_path = os.path.join(project_dir, FLAGS.dockerfile_path)
   extra_pip_specs = (FLAGS.extra_pip_specs or '').replace(';', '')
-  docker_base_cmd = 'docker build --no-cache --pull'
+  docker_base_cmd = 'docker build --no-cache'
+  if FLAGS.docker_pull:
+    docker_base_cmd = docker_base_cmd + ' --pull'
   # FLAGS.extra_docker_build_args will be a list of strings (e.g. ['a', 'b=c']).
   # We treat the strings directly as build-args: --build-arg a --build-arg b=c
   # Empty strings are ignored.


### PR DESCRIPTION
This is useful if the base image has been created locally. Looking for a nonexistent image in a remote repo results in an error.

For tf-agents we build a base image and then build our mujoco image on top of that so users that don't need mujoco do not have to deal with the licensing issues. 