### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/scripts/tf_cnn_benchmarks/batch_allreduce.py
+++ b/scripts/tf_cnn_benchmarks/batch_allreduce.py
@@ -88,7 +88,7 @@ class BatchAllReduceAlgorithm(object):
     [[ A+C,  B+D ],  # These two tensors are on GPU 0
      [ A+C,  B+D ]]  # These two tensors are on GPU 1
 
-    Arguments:
+    Args:
       all_device_tensors: A list of list of tensors. `all_device_tensors[i][j]`
         is a tensor where `i` is the device index and `j` is the tensor index.
       num_splits: If not None, tensors will be concatenated and split into this
@@ -459,7 +459,7 @@ def _defer_tensor(tensor):
 def defer_single_device_tensors(device_tensors):
   """Defer tensors (gradients in this case) from a single device.
 
-  Arguments:
+  Args:
     device_tensors: A list of gradients tensors from a single device to defer.
 
   Returns:
@@ -532,7 +532,7 @@ class _TensorPacker(object):
   def __init__(self, num_splits, compact):
     """Initializes the _TensorPacker.
 
-    Arguments:
+    Args:
       num_splits: The number of tensors to split the concatenated tensor into.
         The batch all-reduce will consist of `num_splits` all-reduces. if None
         or zero, tensors are not split or concatenated.

--- a/scripts/tf_cnn_benchmarks/models/experimental/deepspeech.py
+++ b/scripts/tf_cnn_benchmarks/models/experimental/deepspeech.py
@@ -40,7 +40,7 @@ class DeepSpeechDecoder(object):
   def __init__(self, labels, blank_index=28):
     """Decoder initialization.
 
-    Arguments:
+    Args:
       labels: a string specifying the speech labels for the decoder to use.
       blank_index: an integer specifying index for the blank character. Defaults
         to 28.

--- a/scripts/tf_cnn_benchmarks/models/tf1_only/mobilenet.py
+++ b/scripts/tf_cnn_benchmarks/models/tf1_only/mobilenet.py
@@ -127,7 +127,7 @@ class NoOpScope(object):
 def safe_arg_scope(funcs, **kwargs):
   """Returns `slim.arg_scope` with all None arguments removed.
 
-  Arguments:
+  Args:
     funcs: Functions to pass to `arg_scope`.
     **kwargs: Arguments to pass to `arg_scope`.
 


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420