### PR TITLE
Add tensorflow-text-nightly pip package to the docker

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_tf_cuda_11
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_tf_cuda_11
@@ -84,6 +84,7 @@ RUN curl https://raw.githubusercontent.com/tensorflow/models/master/official/req
 RUN pip install -r /tmp/requirements.txt
 
 RUN pip install tf-estimator-nightly
+RUN pip install tensorflow-text-nightly
 
 # RUN nvidia-smi
 


### PR DESCRIPTION
This is for model garden to use tf-text library.