### PR TITLE
Updating toolchain locations for Swift for TensorFlow Docker images

### DIFF
--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda10.1
@@ -9,7 +9,7 @@ FROM nvidia/cuda:10.1-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu"
 ARG local_tensorflow_pip_spec=""
 ARG extra_pip_specs=""
-ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-ubuntu18.04.tar.gz
+ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda10.1-cudnn7-stock-ubuntu18.04.tar.gz
 
 # setup.py passes the base path of local .whl file is chosen for the docker image.
 # Otherwise passes an empty existing file from the context.

--- a/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda11.0
+++ b/perfzero/docker/Dockerfile_ubuntu_1804_s4tf_cuda11.0
@@ -8,7 +8,7 @@ FROM nvidia/cuda:11.0-base-ubuntu18.04 as base
 ARG tensorflow_pip_spec="tf-nightly-gpu"
 ARG local_tensorflow_pip_spec=""
 ARG extra_pip_specs=""
-ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda11.0-cudnn8-ubuntu18.04.tar.gz
+ARG swift_tf_url=https://storage.googleapis.com/swift-tensorflow-artifacts/nightlies/latest/swift-tensorflow-DEVELOPMENT-cuda11.0-cudnn8-stock-ubuntu18.04.tar.gz
 
 # setup.py passes the base path of local .whl file is chosen for the docker image.
 # Otherwise passes an empty existing file from the context.


### PR DESCRIPTION
Swift for TensorFlow is in the process of migrating to toolchains that are based on the stock Swift compiler. This updates the CUDA 10.1 and CUDA 11.0 Swift for TensorFlow Docker images to the new location of these nightly toolchain builds, so that benchmarks will reflect their performance characteristics.