### PR TITLE
Use time.perf_counter() instead of time.time() to compute durations

### DIFF
--- a/scripts/tf_cnn_benchmarks/all_reduce_benchmark.py
+++ b/scripts/tf_cnn_benchmarks/all_reduce_benchmark.py
@@ -203,10 +203,10 @@ def run_graph(benchmark_op, bench_cnn, init_ops, dummy_loss_op):
     for i in range(-bench_cnn.num_warmup_batches, bench_cnn.num_batches):
       if i == 0:
         log_fn('Running all-reduce ops')
-        start = time.time()
+        start = time.perf_counter()
       if i > 0 and i % bench_cnn.params.display_every == 0:
         log_fn('Iteration: %d. Average time per step so far: %s' %
-               (i, (time.time() - start) / i))
+               (i, (time.perf_counter() - start) / i))
       # Call benchmark_one_step instead of directly calling sess.run(...), to
       # potentially get a trace file, partitioned graphs, etc.
       benchmark_cnn.benchmark_one_step(
@@ -225,7 +225,7 @@ def run_graph(benchmark_op, bench_cnn, init_ops, dummy_loss_op):
           params=bench_cnn.params,
           show_images_per_sec=False)
     log_fn('Average time per step: %s' %
-           ((time.time() - start) / bench_cnn.num_batches))
+           ((time.perf_counter() - start) / bench_cnn.num_batches))
 
 
 def run_benchmark(bench_cnn, num_iters):


### PR DESCRIPTION
To compute durations, `time.perf_counter()` is more reliable than `time.time()`. When `time.time()` is used on Windows in some of the faster benchmark models ran on the GPU (e.g. trivial), the lack in accuracy can result in divisions by zero:

```
E:\tfmodels\benchmarks\scripts\tf_cnn_benchmarks\benchmark_cnn.py:956: RuntimeWarning: invalid value encountered in subtract
  speed_jitter = 1.4826 * np.median(np.abs(speeds - np.median(speeds)))
1       images/sec: inf +/- nan (jitter = nan)  21.622
INFO:tensorflow:Error reported to Coordinator: <class 'ZeroDivisionError'>, float division by zero
I0707 15:12:44.122273   236 coordinator.py:224] Error reported to Coordinator: <class 'ZeroDivisionError'>, float division by zero
Traceback (most recent call last):
  File "E:\tfmodels\benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py", line 75, in <module>
    app.run(main)  # Raises error on invalid flags, unlike tf.app.run()
  File "C:\Users\pavignol\Miniconda3\envs\tfgpu\lib\site-packages\absl\app.py", line 312, in run
    _run_main(main, args)
  File "C:\Users\pavignol\Miniconda3\envs\tfgpu\lib\site-packages\absl\app.py", line 258, in _run_main
    sys.exit(main(argv))
  File "E:\tfmodels\benchmarks/scripts/tf_cnn_benchmarks/tf_cnn_benchmarks.py", line 70, in main
    bench.run()
  File "E:\tfmodels\benchmarks\scripts\tf_cnn_benchmarks\benchmark_cnn.py", line 1883, in run
    return self._benchmark_train()
  File "E:\tfmodels\benchmarks\scripts\tf_cnn_benchmarks\benchmark_cnn.py", line 2088, in _benchmark_train
    return self._benchmark_graph(result_to_benchmark, eval_build_results)
  File "E:\tfmodels\benchmarks\scripts\tf_cnn_benchmarks\benchmark_cnn.py", line 2295, in _benchmark_graph
    is_chief, summary_writer, profiler)
  File "E:\tfmodels\benchmarks\scripts\tf_cnn_benchmarks\benchmark_cnn.py", line 2482, in benchmark_with_session
    elapsed_time)
ZeroDivisionError: float division by zero
```