### PR TITLE
Remove nargs from flag --perfzero_constructor_args

### DIFF
--- a/perfzero/lib/perfzero/perfzero_config.py
+++ b/perfzero/lib/perfzero/perfzero_config.py
@@ -266,7 +266,6 @@ def add_benchmark_parser_arguments(parser):
       ''')
   parser.add_argument(
       '--perfzero_constructor_args',
-      nargs='*',
       default='',
       type=str,
       help='''A json dictionary of additional args to pass to the perfzero


### PR DESCRIPTION
There should only ever be one argument to --perfzero_constructor_args (as all the args are grouped together in a JSON-serialized dict).